### PR TITLE
Enhance Renovate configuration and disable Dependabot duplicates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependency management is handled by Renovate (see renovate.json).
+# This file intentionally disables Dependabot version updates so the two
+# bots do not produce duplicate PRs for the same dependency.
+#
+# Note: Dependabot *security* updates are configured separately and cannot
+# be disabled via this file. To turn them off, go to:
+#   Settings -> Code security -> Dependabot security updates
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,30 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":semanticCommitsDisabled"
+    "config:recommended",
+    ":semanticCommitsDisabled",
+    ":dependencyDashboard"
   ],
-  "ignoreDeps": [],
-  "labels": ["Renovate"],
-  "rebaseWhen": "conflicted",
-  "schedule": ["on the first day of the month"]
+  "labels": ["dependencies", "Renovate"],
+  "rebaseWhen": "behind-base-branch",
+  "schedule": ["before 6am on the first day of the month"],
+  "prConcurrentLimit": 10,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"]
+  },
+  "packageRules": [
+    {
+      "groupName": "patch updates",
+      "matchUpdateTypes": ["patch"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major-update"],
+      "dependencyDashboardApproval": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"]
+  }
 }


### PR DESCRIPTION
## Summary
This PR upgrades and enhances the Renovate dependency management configuration while adding a Dependabot configuration to prevent duplicate pull requests from both bots.

## Key Changes

- **Upgraded Renovate base config**: Changed from `config:base` to `config:recommended` for more comprehensive dependency management
- **Enabled Dependency Dashboard**: Added `:dependencyDashboard` preset for better visibility into dependency updates
- **Enhanced scheduling**: Updated schedule from "on the first day of the month" to "before 6am on the first day of the month" for more predictable timing
- **Improved rebase strategy**: Changed `rebaseWhen` from "conflicted" to "behind-base-branch" for better branch synchronization
- **Added concurrent PR limits**: Set `prConcurrentLimit` to 10 to prevent overwhelming the repository with simultaneous PRs
- **Implemented lock file maintenance**: Enabled automatic lock file updates on a monthly schedule
- **Added package rules**:
  - Group patch updates together for easier management
  - Require dashboard approval for major version updates and add a "major-update" label for visibility
- **Enhanced labeling**: Updated labels to include "dependencies" alongside "Renovate" for better organization
- **Added security alert handling**: Configured separate labeling for vulnerability alerts with a "security" label
- **Disabled Dependabot version updates**: Added `.github/dependabot.yml` to disable Dependabot's version update checks (set `open-pull-requests-limit: 0`) while preserving security update functionality, preventing duplicate PRs from both bots

## Implementation Details
The Dependabot configuration includes a note that security updates are managed separately and cannot be disabled via this file, requiring manual configuration in repository settings if needed.

https://claude.ai/code/session_01VF8MEsYm6QggbswvfexiB3