### PR TITLE
chore(renovate): adopt shared org preset with maintainers-launchpad reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":semanticCommitsDisabled",
-    ":dependencyDashboard"
-  ],
-  "labels": ["dependencies", "Renovate"],
-  "rebaseWhen": "behind-base-branch",
-  "schedule": ["before 6am on the first day of the month"],
-  "prConcurrentLimit": 10,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 6am on the first day of the month"]
-  },
-  "packageRules": [
-    {
-      "groupName": "patch updates",
-      "matchUpdateTypes": ["patch"]
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "addLabels": ["major-update"],
-      "dependencyDashboardApproval": true
-    }
-  ],
-  "vulnerabilityAlerts": {
-    "labels": ["security"]
-  }
+    "github>onelitefeathernet/renovate:default(onelitefeathernet/maintainers-launchpad)"
+  ]
 }


### PR DESCRIPTION
## Summary
- Drop the locally maintained Renovate config in favour of the shared org preset `github>onelitefeathernet/renovate:default(...)`.
- Pass `onelitefeathernet/maintainers-launchpad` as the reviewer team so Renovate PRs are routed to the launchpad maintainers specifically.

## What the preset gives us
- `config:recommended` baseline
- `:automergePatch` — patch updates auto-merge during office hours
- `:reviewer(onelitefeathernet/maintainers-launchpad)`
- `Europe/Berlin` timezone, `schedule:officeHours`, `schedule:automergeOfficeHours`
- `:semanticCommits` (`chore(deps):` prefix again, aligning with semantic-release)
- `:label(renovate)`
- `:enableVulnerabilityAlerts`
- `rebaseWhen: conflicted`

This replaces the custom config that PR #104 introduced (`config:recommended` + ad-hoc package rules) with the canonical org-wide configuration so launchpad behaves like every other repo in the org.

## Test plan
- [ ] Renovate Dependency Dashboard issue refreshes on next run
- [ ] Next Renovate PR is labelled `renovate` and requests review from `@onelitefeathernet/maintainers-launchpad`
- [ ] Patch updates auto-merge during office hours

https://claude.ai/code/session_01VF8MEsYm6QggbswvfexiB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VF8MEsYm6QggbswvfexiB3)_