### PR TITLE
chore: bump engines.node to >=22.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Raise `engines.node` from `>=20.10.0` to `>=22.0.0` (Node 22 is the current active LTS, supported until 2027-04).

## Why
`better-sqlite3` v12.10+ (#36) drops prebuilt binaries for Node 20. Without this bump, deploying or running `pnpm install` on Node 20 after merging #36 would fall back to compiling the native module from source (build toolchain required, much slower installs). Aligning the engine pin with the LTS line keeps installs fast and prevents accidental fallback to source builds.

## Impact
- Local dev environments and CI runners must be on Node 22.x
- No runtime API surface change — Node 22 is binary-compatible with the code that runs today

## Follow-up
Once this lands, #36 (`better-sqlite3` 12.4.6 → 12.10.0) can be merged cleanly.

## Test plan
- [ ] Verify CI/deploy environments are on Node 22 (or update them)
- [ ] `pnpm install` on a clean checkout
- [ ] `pnpm build` succeeds

https://claude.ai/code/session_01VF8MEsYm6QggbswvfexiB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VF8MEsYm6QggbswvfexiB3)_