### PR TITLE
fix(blog): restore blog subpage rendering

### DIFF
--- a/composables/usePageSeo.ts
+++ b/composables/usePageSeo.ts
@@ -91,7 +91,7 @@ export function usePageSeo(opts: PageSeoOptions = {}) {
   })
 
   // Auto-generate OG image via nuxt-og-image for every page
-  defineOgImage({
+  defineOgImage('NuxtSeo', {
     title: opts.title || site.name || 'OneLiteFeather',
     description: pageDescription.value
   })

--- a/content.config.ts
+++ b/content.config.ts
@@ -1,4 +1,5 @@
-import { defineContentConfig, defineCollection, z } from '@nuxt/content'
+import { defineContentConfig, defineCollection } from '@nuxt/content'
+import { z } from 'zod'
 import { asSchemaOrgCollection } from 'nuxt-schema-org/content'
 import {
   defineLocalizedCollections,

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -111,7 +111,7 @@ useSchemaOrg([{
   ]
 }])
 
-defineOgImage({
+defineOgImage('NuxtSeo', {
   title: blog.value?.title || t('blog.overview.title'),
   description: blog.value?.description || ''
 })


### PR DESCRIPTION
The blog detail pages crashed with two regressions after recent dependency
updates:

- @nuxtjs/sitemap v7 and nuxt-schema-org v5 pin zod v4, and their
  asSitemapCollection / asSchemaOrgCollection helpers re-build the
  collection schema with that v4 zod. The blog schema in content.config.ts
  used the zod3 re-export from @nuxt/content, producing a mixed
  v4-outer / v3-inner schema that silently failed JSON Schema conversion.
  As a result the blog_de / blog_en tables were created without slug,
  pubDate, tags, ... columns, so queryCollection(...).where('slug', ...)
  hit "no such column: slug". Switching the content.config import to the
  top-level zod (v4) keeps all schemas in one zod major version.

- nuxt-og-image v6 changed defineOgImage() to require the component name
  as the first argument; passing an options object made resolveComponentName
  try to .split() that object. Updated both call sites to defineOgImage(
  'NuxtSeo', { title, description }).