### PR TITLE
Change Nitro preset from cloudflare_pages to cloudflare_module

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -228,7 +228,7 @@ export default defineNuxtConfig({
             }
         },
         nitro: {
-            preset: "cloudflare_pages",
+            preset: "cloudflare_module",
             externals: {
                 inline: ["@nuxt/content"]
             },


### PR DESCRIPTION
## Summary
Updated the Nitro preset configuration to use `cloudflare_module` instead of `cloudflare_pages` for improved compatibility with Cloudflare's module-based deployment approach.

## Key Changes
- Changed `nitro.preset` from `"cloudflare_pages"` to `"cloudflare_module"` in `nuxt.config.ts`

## Details
This change updates the deployment target for the Nitro server, switching from Cloudflare Pages preset to the Cloudflare Module preset. This allows the application to leverage Cloudflare's module-based runtime environment, which may provide better performance, compatibility, or feature support compared to the Pages preset.

https://claude.ai/code/session_012YWscdohmouZHhZ7otKnqh