### PR TITLE
fix: inline axios so cloudflare_module Worker deploy succeeds

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -286,7 +286,7 @@ export default defineNuxtConfig({
         nitro: {
             preset: "cloudflare_module",
             externals: {
-                inline: ["@nuxt/content"]
+                inline: ["@nuxt/content", "axios"]
             },
             cloudflare: {
                 deployConfig: true,


### PR DESCRIPTION
## Summary
Follow-up to #125. The `cloudflare_module` preset is now on `main`, but the Worker deploy fails:

```
✘ [ERROR] Could not resolve "axios"
  .output/server/chunks/build/server.mjs: ...if(!cw){const e=require("axios");...
```

`posthog-node` (used server-side by `nuxt-posthog`) does a lazy `require("axios")`. Under the old `cloudflare_pages` preset Nitro bundled everything itself; under `cloudflare_module` Nitro leaves `axios` as an external `require` that wrangler's esbuild cannot resolve in `.output` (no `node_modules` there).

## Change
- Add `axios` to `nitro.externals.inline` so Nitro bundles it into the server output, reproducing the prior bundling behaviour. Runtime behaviour is unchanged (the same code already ran in the previous Pages Worker).

One-line change in `nuxt.config.ts`.

## Test plan
- [ ] Cloudflare build + `wrangler deploy` completes without the `Could not resolve "axios"` error
- [ ] Site renders and PostHog server-side events still work

https://claude.ai/code/session_012YWscdohmouZHhZ7otKnqh

---
_Generated by [Claude Code](https://claude.ai/code/session_012YWscdohmouZHhZ7otKnqh)_