### PR TITLE
chore: clear real build warnings (tsconfig, postcss, protobufjs)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -142,12 +142,6 @@ export default defineNuxtConfig({
             baseURL: 'https://img.onelitefeather.net',
         }
     },
-    postcss: {
-        plugins: {
-            "@tailwindcss/postcss": {},
-            'postcss-import': {},
-        },
-    },
     posthog: {
         publicKey: 'phc_t9nBlYL9LcDj4LDKZfQ97m5nbvFDTugkdQqAAspfdI',
         host: 'https://eu.i.posthog.com',

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ onlyBuiltDependencies:
   - better-sqlite3
   - core-js
   - esbuild
+  - protobufjs
   - sharp
   - unrs-resolver
   - vue-demi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
   "extends": "./.nuxt/tsconfig.json",
-  "verbatimModuleSyntax": false
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  }
 }


### PR DESCRIPTION
## Summary
Removes the build/deploy warnings that stem from actual misconfiguration in this repo (the only ones cleanly fixable; the remaining noise comes from dependency code — `fast-xml-parser`, `@vueuse/core` — and is out of scope here).

## Changes
- **tsconfig.json**: `verbatimModuleSyntax` was at the top level; moved it into `compilerOptions`. Clears the esbuild/wrangler warning `Expected the "verbatimModuleSyntax" option to be nested inside a "compilerOptions" object`.
- **nuxt.config.ts**: dropped the redundant `postcss` block. With Tailwind v4 the `@tailwindcss/vite` plugin (already in `vite.plugins`) handles CSS/`@import`, so the separate `@tailwindcss/postcss` + `postcss-import` config was conflicting and produced `could not import postcss plugin 'postcss-import'`.
- **pnpm-workspace.yaml**: added `protobufjs` to `onlyBuiltDependencies`, clearing the `Ignored build scripts: protobufjs` warning.

## Out of scope (dependency-side, only suppressible)
`Duplicate key "euro"` (fast-xml-parser), `@vueuse/core` PURE-comment, sourcemap plugin noise, the >500 kB chunk notice and the `@nuxt/content` D1 info line are intentionally left as-is.

## Test plan
- [ ] Build completes; the three warnings above no longer appear
- [ ] CSS/Tailwind still renders correctly (golden path + dark mode)
- [ ] Cloudflare Worker deploy still succeeds

https://claude.ai/code/session_012YWscdohmouZHhZ7otKnqh

---
_Generated by [Claude Code](https://claude.ai/code/session_012YWscdohmouZHhZ7otKnqh)_