### PR TITLE
perf: tree-shake FontAwesome to shrink the main client chunk

### DIFF
--- a/plugins/fontawesome.js
+++ b/plugins/fontawesome.js
@@ -1,23 +1,70 @@
 import { library, config } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { fas } from '@fortawesome/free-solid-svg-icons'
-import { fab } from '@fortawesome/free-brands-svg-icons'
+import {
+    faArrowRight,
+    faBars,
+    faCheck,
+    faChevronDown,
+    faChevronLeft,
+    faChevronRight,
+    faEllipsisH,
+    faEnvelope,
+    faFileAlt,
+    faHome,
+    faLink,
+    faLocationDot,
+    faMap,
+    faServer,
+    faShareNodes,
+    faSignal,
+    faTimes
+} from '@fortawesome/free-solid-svg-icons'
+import {
+    faBluesky,
+    faDiscord,
+    faFacebookF,
+    faLinkedinIn,
+    faRedditAlien,
+    faTelegram,
+    faWhatsapp,
+    faXTwitter
+} from '@fortawesome/free-brands-svg-icons'
 
 // This is important, we are going to let Nuxt worry about the CSS
 config.autoAddCss = false
 
-// You can add your icons directly in this plugin. See other examples for how you
-// can add other styles or just individual icons.
-library.add(fas)
-library.add(fab)
+// Only the icons referenced via the global library (the `['fas'|'fab', 'name']`
+// string syntax) are registered here. Components that import icon objects directly
+// are tree-shaken on their own. When adding a new `['fas'|'fab', 'name']` reference,
+// add the matching icon below as well, otherwise it renders empty.
+library.add(
+    faArrowRight,
+    faBars,
+    faCheck,
+    faChevronDown,
+    faChevronLeft,
+    faChevronRight,
+    faEllipsisH,
+    faEnvelope,
+    faFileAlt,
+    faHome,
+    faLink,
+    faLocationDot,
+    faMap,
+    faServer,
+    faShareNodes,
+    faSignal,
+    faTimes,
+    faBluesky,
+    faDiscord,
+    faFacebookF,
+    faLinkedinIn,
+    faRedditAlien,
+    faTelegram,
+    faWhatsapp,
+    faXTwitter
+)
 
 export default defineNuxtPlugin((nuxtApp) => {
     nuxtApp.vueApp.component('font-awesome-icon', FontAwesomeIcon)
 })
-
-// // Modify the `nuxt.config.ts` file by adding to the `export default defineNuxtConfig()`
-// export default defineNuxtConfig({
-//     css: [
-//         '@fortawesome/fontawesome-svg-core/styles.css'
-//     ]
-// })


### PR DESCRIPTION
## Summary
The build warned that the main client chunk (`AiF14EdV.js`) was ~2 MB / ~701 kB gzip. Cause: `plugins/fontawesome.js` registered the **entire** free-solid + free-brands icon sets via `library.add(fas)` / `library.add(fab)` (~2000 icons), while the app only references ~25 via the global `['fas'|'fab', 'name']` string syntax.

## Change
- `plugins/fontawesome.js`: import and register only the 25 icons actually used through the global library. Components that import icon objects directly (`faCopy`, `faLanguage`, …) were already tree-shaken and are untouched.

All 25 icon export names were verified against the installed `@fortawesome/free-{solid,brands}-svg-icons@7.2.0`. No dynamic/computed icon names exist in the codebase, so tree-shaking is safe; a missing registration would render an empty icon, so the icon list was enumerated exhaustively from the source.

Expected effect: the ~2 MB chunk drops by roughly 1.5–2 MB.

## Test plan
- [ ] Build succeeds; main client chunk significantly smaller, >500 kB warning reduced/gone
- [ ] Icons still render across: navigation bar + mobile menu, language selector, blog/article cards, FAQ, social share buttons, footer/contact, server sections (spot-check each `['fas'|'fab', …]` usage)
- [ ] Workers deploy still succeeds

https://claude.ai/code/session_012YWscdohmouZHhZ7otKnqh

---
_Generated by [Claude Code](https://claude.ai/code/session_012YWscdohmouZHhZ7otKnqh)_