### PR TITLE
Centralize i18n canonical/hreflang generation and fix blog slug handling

### DIFF
--- a/components/features/navigation/LanguageSelector.vue
+++ b/components/features/navigation/LanguageSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, navigateTo, onMounted, onBeforeUnmount } from '#imports';
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from '#imports';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faLanguage, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 const { t } = useI18n();
@@ -9,8 +9,7 @@ const props = defineProps<{
 }>();
 
 const variant = props.variant ?? 'desktop';
-const { locale, locales, setLocale } = useI18n();
-const switchLocalePath = useSwitchLocalePath();
+const { locale, locales } = useI18n();
 const isOpen = ref(false);
 const buttonRef = ref<HTMLButtonElement | null>(null);
 const menuRef = ref<HTMLElement | null>(null);
@@ -116,16 +115,12 @@ onBeforeUnmount(() => {
 // Inform parent (e.g., mobile overlay) when a language was selected
 const emit = defineEmits<{ (e: 'selected', locale: string): void }>();
 
-const selectLocale = async (localeCode: string) => {
-  // Sprache setzen und dann ausdrücklich zur sprachspezifischen Route navigieren,
-  // damit die URL korrekt aktualisiert wird und serverseitige Navigation greift.
-  await setLocale(localeCode as 'de' | 'en');
-  const targetPath = switchLocalePath(localeCode);
-  if (targetPath) {
-    await navigateTo(targetPath);
-  }
+// Navigation is handled by <SwitchLocalePathLink>, which resolves the
+// correct localized path (including translated blog slugs via
+// useSetI18nParams). We only handle the UI side-effects here.
+const onSelect = (localeCode: string) => {
   emit('selected', localeCode);
-  closeDropdown(true);
+  closeDropdown(false);
 };
 </script>
 
@@ -166,17 +161,17 @@ const selectLocale = async (localeCode: string) => {
         @keydown="onMenuKeydown"
         class="absolute right-0 mt-2 w-48 overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-lg ring-1 ring-black/5 dark:border-[var(--color-border)] dark:bg-[var(--color-surface)]"
       >
-        <NuxtLink
+        <SwitchLocalePathLink
           v-for="loc in availableLocales"
           :key="loc.code"
-          :to="switchLocalePath(loc.code)"
+          :locale="loc.code"
           role="menuitem"
           class="flex items-center gap-3 px-4 py-2 text-sm font-medium text-[var(--color-text)]/70 transition-colors hover:bg-[var(--color-secondary)]/10 dark:text-[var(--color-text)]/85 dark:hover:bg-[var(--color-secondary)]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-secondary)]"
-          @click.prevent="selectLocale(loc.code)"
+          @click="onSelect(loc.code)"
         >
           <span class="uppercase font-semibold text-[var(--color-secondary)]">{{ loc.code }}</span>
           <span>{{ loc.name }}</span>
-        </NuxtLink>
+        </SwitchLocalePathLink>
       </div>
     </Transition>
   </div>
@@ -186,15 +181,15 @@ const selectLocale = async (localeCode: string) => {
       <FontAwesomeIcon :icon="faLanguage" class="text-xl" />
       {{ t('navigation.change_language') }}
     </div>
-    <NuxtLink
+    <SwitchLocalePathLink
       v-for="loc in availableLocales"
       :key="loc.code"
-      :to="switchLocalePath(loc.code)"
+      :locale="loc.code"
       class="ml-4 flex items-center gap-3 rounded-xl px-6 py-2 text-sm font-medium text-[var(--color-text)]/70 transition-colors hover:bg-[var(--color-secondary)]/10 dark:text-[var(--color-text)]/85 dark:hover:bg-[var(--color-secondary)]/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-secondary)]"
-      @click.prevent="selectLocale(loc.code)"
+      @click="onSelect(loc.code)"
     >
       <span class="uppercase font-semibold text-[var(--color-secondary)]">{{ loc.code }}</span>
       <span>{{ loc.name }}</span>
-    </NuxtLink>
+    </SwitchLocalePathLink>
   </div>
 </template>

--- a/composables/useBlogContent.ts
+++ b/composables/useBlogContent.ts
@@ -3,13 +3,11 @@ import type { PageCollectionItemBase } from '@nuxt/content'
 import type { LocaleObject } from 'vue-i18n-routing'
 import type {
   BlogArticle,
-  BlogAlternateLanguageLink,
   BlogAlternateHeader,
   BlogAuthorProfile
 } from '~/types/blog'
 
 type BlogCollectionKey = 'blog_de' | 'blog_en'
-type HeadLink = { rel: string; href: string; hreflang?: string; type?: string }
 type AuthorCollectionItem = BlogAuthorProfile & PageCollectionItemBase
 
 declare module '@nuxt/content' {
@@ -45,9 +43,6 @@ const normalizeLocales = (list: unknown[]): LocaleObject[] =>
         Boolean(locale && typeof locale === 'object' && 'code' in (locale as Record<string, unknown>))
     )
     .map((locale) => locale as LocaleObject)
-
-const resolveHreflang = (locale: LocaleObject, fallback: string): string =>
-  locale.iso || (locale as { _hreflang?: string })._hreflang || locale.code || fallback
 
 // Last non-empty path segment of a (possibly absolute) URL — the blog slug.
 const slugFromUrl = (url: string): string | undefined => {
@@ -148,7 +143,6 @@ export function useBlogOverview(options: BlogOverviewOptions = {}) {
 export async function useBlogArticle() {
   const { locale, locales } = useI18n()
   const route = useRoute()
-  const config = useRuntimeConfig()
   const blogCollection = computed<BlogCollectionKey>(
     () => (`blog_${locale?.value || 'de'}`) as BlogCollectionKey
   )
@@ -239,16 +233,11 @@ export async function useBlogArticle() {
     return { ...(article.value as BlogArticle), authors: authors.value || [] }
   })
 
-  const alternateLanguages = ref<BlogAlternateLanguageLink[]>([])
-
-  // Helper to resolve a base URL
-  const resolveBaseUrl = (): string => {
-    const pub = config.public as { siteUrl?: string; baseUrl?: string }
-    return pub.siteUrl || pub.baseUrl || 'https://onelitefeather.net'
-  }
-
-  // Push the per-locale slugs into Nuxt i18n so the language switcher links
-  // to the translated article URL rather than reusing the current slug.
+  // Publish the per-locale slugs into Nuxt i18n. This is what makes
+  // switchLocalePath / <SwitchLocalePathLink> AND the i18n-generated
+  // canonical + hreflang tags (see layouts/default.vue) resolve to the
+  // correctly translated article URL instead of reusing the current
+  // language's slug.
   const publishLocaleParams = (localeSlugs: Record<string, string>) => {
     const params: Record<string, { slug: string[] }> = {}
     for (const [code, value] of Object.entries(localeSlugs)) {
@@ -257,20 +246,18 @@ export async function useBlogArticle() {
     if (Object.keys(params).length) setI18nParams(params)
   }
 
-  // Rebuild alternates whenever article/locale changes
+  // Resolve the translated slug for every locale whenever article/locale
+  // changes, from front-matter `alternates` when present, else by matching
+  // `translationKey` across the localized collections.
   watch([blog, locale, locales], async () => {
-    alternateLanguages.value = []
     if (!blog.value) return
 
-    // Always know the current locale's own slug.
     const localeSlugs: Record<string, string> = {}
     if (blog.value.slug) localeSlugs[locale.value] = blog.value.slug
 
     if (blog.value.alternates && Array.isArray(blog.value.alternates)) {
       for (const alt of blog.value.alternates as BlogAlternateHeader[]) {
         if (!alt?.hreflang || !alt?.href) continue
-        alternateLanguages.value.push({ locale: alt.hreflang, url: alt.href })
-
         const code = localeCodeFromHreflang(alt.hreflang, availableLocales.value)
         const altSlug = slugFromUrl(alt.href)
         if (code && altSlug) localeSlugs[code] = altSlug
@@ -285,90 +272,19 @@ export async function useBlogArticle() {
     }
 
     const otherLocales = availableLocales.value.filter((l) => l.code !== locale.value)
-
-    const baseUrl = resolveBaseUrl()
     for (const otherLocale of otherLocales) {
       const translated = await queryCollection(`blog_${otherLocale.code}` as BlogCollectionKey)
         .where('translationKey', '=', blog.value?.translationKey)
         .first()
-
-      if (translated) {
-        const hreflangValue = resolveHreflang(otherLocale, otherLocale.code)
-        const translatedSlug = (translated as BlogArticle).slug
-
-        alternateLanguages.value.push({
-          locale: hreflangValue,
-          url: `${baseUrl}/${otherLocale.code}/blog/${translatedSlug}`
-        })
-        if (translatedSlug) localeSlugs[otherLocale.code] = translatedSlug
-      }
+      const translatedSlug = (translated as BlogArticle | null)?.slug
+      if (translatedSlug) localeSlugs[otherLocale.code] = translatedSlug
     }
 
     publishLocaleParams(localeSlugs)
   }, { immediate: true })
 
-  // Canonical + hreflang Informationen für den Head
-  const headLinks = computed<HeadLink[]>(() => {
-    const links: HeadLink[] = []
-    // add favicon
-    links.push({ rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' })
-
-    if (!blog.value) return links
-
-    const baseUrl = resolveBaseUrl()
-
-    const currentLocaleObj =
-      availableLocales.value.find((l) => l.code === locale.value) ||
-      ({ code: locale.value } as LocaleObject)
-    const currentHreflang = resolveHreflang(currentLocaleObj, locale.value)
-
-    // Prefer explicit canonical from front-matter, else compute fallback
-    const canonicalUrl =
-      blog.value.canonical || `${baseUrl}/${locale.value}/blog/${blog.value.slug}`
-
-    links.push({ rel: 'canonical', href: canonicalUrl })
-
-    // Build a de-dup set for alternates
-    const seen = new Set<string>()
-    const pushAlt = (hreflang: string, href: string) => {
-      const key = `${hreflang}::${href}`
-      if (seen.has(key)) return
-      seen.add(key)
-      links.push({ rel: 'alternate', hreflang, href })
-    }
-
-    if (blog.value.alternates && Array.isArray(blog.value.alternates)) {
-      for (const alt of blog.value.alternates as BlogAlternateHeader[]) {
-        if (!alt?.hreflang || !alt?.href) continue
-        pushAlt(alt.hreflang, alt.href)
-      }
-      // Ensure current locale is present
-      const hasCurrent = [...seen].some((k) => k.startsWith(`${currentHreflang}::`))
-      if (!hasCurrent) pushAlt(currentHreflang, canonicalUrl)
-    } else {
-      // Fallback: generate alternates programmatically from computed ref
-      pushAlt(currentHreflang, canonicalUrl)
-      for (const alt of alternateLanguages.value) pushAlt(alt.locale, alt.url)
-
-      const defaultLocale = 'en'
-      if (locale.value === defaultLocale) {
-        pushAlt('x-default', canonicalUrl)
-      } else {
-        const defaultLocaleUrl =
-          alternateLanguages.value.find(
-            (alt) => alt.locale?.startsWith('en') || alt.locale === 'en'
-          )?.url || `${baseUrl}/${defaultLocale}/blog/${blog.value.slug}`
-        pushAlt('x-default', defaultLocaleUrl)
-      }
-    }
-
-    return links
-  })
-
   return {
     blog,
-    authors,
-    alternateLanguages,
-    headLinks
+    authors
   }
 }

--- a/composables/useBlogContent.ts
+++ b/composables/useBlogContent.ts
@@ -49,6 +49,27 @@ const normalizeLocales = (list: unknown[]): LocaleObject[] =>
 const resolveHreflang = (locale: LocaleObject, fallback: string): string =>
   locale.iso || (locale as { _hreflang?: string })._hreflang || locale.code || fallback
 
+// Last non-empty path segment of a (possibly absolute) URL — the blog slug.
+const slugFromUrl = (url: string): string | undefined => {
+  try {
+    const path = url.includes('://') ? new URL(url).pathname : url
+    return path.split('/').filter(Boolean).at(-1)
+  } catch {
+    return url.split('/').filter(Boolean).at(-1)
+  }
+}
+
+// Map an hreflang value (e.g. `de`, `de-DE`) back to a configured locale code.
+const localeCodeFromHreflang = (
+  hreflang: string,
+  available: LocaleObject[]
+): string | undefined => {
+  const match = available.find(
+    (l) => l.code === hreflang || l.iso === hreflang || hreflang.split('-')[0] === l.code
+  )
+  return match?.code
+}
+
 export interface BlogOverviewOptions {
   /**
    * Optional current page (1-based) for future pagination.
@@ -124,7 +145,7 @@ export function useBlogOverview(options: BlogOverviewOptions = {}) {
  * Fetches a single blog article and its translations in other languages.
  * Uses i18n information together with @nuxt/content.
  */
-export function useBlogArticle() {
+export async function useBlogArticle() {
   const { locale, locales } = useI18n()
   const route = useRoute()
   const config = useRuntimeConfig()
@@ -134,6 +155,12 @@ export function useBlogArticle() {
   const availableLocales = computed<LocaleObject[]>(() =>
     normalizeLocales((locales.value || []) as unknown[])
   )
+
+  // Lets `switchLocalePath`/`<SwitchLocalePathLink>` resolve the correct
+  // localized slug instead of naively reusing the current one — blog posts
+  // use a different slug per language, so without this the language switcher
+  // produces a 404.
+  const setI18nParams = useSetI18nParams()
 
   // Slug derived from catch-all route param; reactive on client navigation
   const slugSegments = computed<string[]>(() => {
@@ -156,7 +183,7 @@ export function useBlogArticle() {
   // slugs — that key was empty during setup, so SSR captured an empty
   // authors list and the rendered author cards and Article JSON-LD shipped
   // without any author data.
-  const { data: payload } = useAsyncData<{
+  const { data: payload } = await useAsyncData<{
     article: BlogArticle | null
     authors: BlogAuthorProfile[]
   } | null>(
@@ -168,11 +195,13 @@ export function useBlogArticle() {
         .where('slug', '=', slug.value)
         .first()) as BlogArticle | null
 
-      if (doc && !isReleased(doc)) {
-        throw createError({ statusCode: 404, statusMessage: 'Article not released' })
+      // A missing or not-yet-released article is a 404. Returning a marker
+      // (instead of throwing here) lets us raise a single fatal error after
+      // the data resolves, which reliably renders the error page with the
+      // correct HTTP status during SSR.
+      if (!doc || !isReleased(doc)) {
+        return { article: null, authors: [] }
       }
-
-      if (!doc) return { article: null, authors: [] }
 
       const slugs = (Array.isArray(doc.author) ? doc.author : [doc.author])
         .filter(Boolean)
@@ -196,6 +225,12 @@ export function useBlogArticle() {
     { watch: [locale, slug] }
   )
 
+  // A requested slug that resolves to no (released) article must surface a
+  // real 404 page instead of silently rendering an empty article.
+  if (slug.value && !payload.value?.article) {
+    throw createError({ statusCode: 404, statusMessage: 'Article not found', fatal: true })
+  }
+
   const article = computed<BlogArticle | null>(() => payload.value?.article || null)
   const authors = computed<BlogAuthorProfile[]>(() => payload.value?.authors || [])
 
@@ -212,20 +247,42 @@ export function useBlogArticle() {
     return pub.siteUrl || pub.baseUrl || 'https://onelitefeather.net'
   }
 
+  // Push the per-locale slugs into Nuxt i18n so the language switcher links
+  // to the translated article URL rather than reusing the current slug.
+  const publishLocaleParams = (localeSlugs: Record<string, string>) => {
+    const params: Record<string, { slug: string[] }> = {}
+    for (const [code, value] of Object.entries(localeSlugs)) {
+      if (value) params[code] = { slug: [value] }
+    }
+    if (Object.keys(params).length) setI18nParams(params)
+  }
+
   // Rebuild alternates whenever article/locale changes
   watch([blog, locale, locales], async () => {
     alternateLanguages.value = []
     if (!blog.value) return
 
+    // Always know the current locale's own slug.
+    const localeSlugs: Record<string, string> = {}
+    if (blog.value.slug) localeSlugs[locale.value] = blog.value.slug
+
     if (blog.value.alternates && Array.isArray(blog.value.alternates)) {
       for (const alt of blog.value.alternates as BlogAlternateHeader[]) {
         if (!alt?.hreflang || !alt?.href) continue
         alternateLanguages.value.push({ locale: alt.hreflang, url: alt.href })
+
+        const code = localeCodeFromHreflang(alt.hreflang, availableLocales.value)
+        const altSlug = slugFromUrl(alt.href)
+        if (code && altSlug) localeSlugs[code] = altSlug
       }
+      publishLocaleParams(localeSlugs)
       return
     }
 
-    if (!blog.value.translationKey) return
+    if (!blog.value.translationKey) {
+      publishLocaleParams(localeSlugs)
+      return
+    }
 
     const otherLocales = availableLocales.value.filter((l) => l.code !== locale.value)
 
@@ -237,13 +294,17 @@ export function useBlogArticle() {
 
       if (translated) {
         const hreflangValue = resolveHreflang(otherLocale, otherLocale.code)
+        const translatedSlug = (translated as BlogArticle).slug
 
         alternateLanguages.value.push({
           locale: hreflangValue,
-          url: `${baseUrl}/${otherLocale.code}/blog/${(translated as BlogArticle).slug}`
+          url: `${baseUrl}/${otherLocale.code}/blog/${translatedSlug}`
         })
+        if (translatedSlug) localeSlugs[otherLocale.code] = translatedSlug
       }
     }
+
+    publishLocaleParams(localeSlugs)
   }, { immediate: true })
 
   // Canonical + hreflang Informationen für den Head

--- a/composables/usePageSeo.ts
+++ b/composables/usePageSeo.ts
@@ -18,51 +18,43 @@ const buildRobots = (opts: PageSeoOptions): string | undefined => {
 }
 
 export function usePageSeo(opts: PageSeoOptions = {}) {
-  const { locale, locales, t } = useI18n()
+  const { locale, t } = useI18n()
   const route = useRoute()
   const site = useSiteConfig()
   const switchLocalePath = useSwitchLocalePath()
   const img = useImage()
   const runtime = useRuntimeConfig()
 
+  // Absolute, query/hash-free URL. `switchLocalePath` preserves the current
+  // request's query string, so without stripping it every tracking param
+  // (utm/fbclid/posthog…) would spawn a distinct canonical + hreflang set
+  // and Google would report duplicates / pick its own canonical.
+  const cleanUrl = (path: string): string => {
+    const u = new URL(path || '/', site.url)
+    u.search = ''
+    u.hash = ''
+    return u.toString()
+  }
+
+  // Canonical must be byte-identical to this locale's self-referencing
+  // hreflang entry below, otherwise the two become conflicting signals.
   const canonicalUrl = computed(() => {
-    if (opts.canonical) return new URL(opts.canonical, site.url).toString()
-    return new URL(route.fullPath || '/', site.url).toString()
+    if (opts.canonical) return cleanUrl(new URL(opts.canonical, site.url).toString())
+    return cleanUrl(switchLocalePath(locale.value) || route.path || '/')
   })
 
-  // Build hreflang alternate links for all configured locales + x-default
-  const alternateLinks = computed(() => {
-    const items: Array<{ rel: 'alternate'; hreflang: string; href: string }> = []
-    const all = Array.isArray(locales.value) ? locales.value : []
-    for (const l of all as Array<any>) {
-      const code = typeof l === 'string' ? l : l.code
-      const iso = typeof l === 'string' ? l : (l.iso || l.code)
-      const path = switchLocalePath(code) || '/'
-      const href = new URL(path, site.url).toString()
-      items.push({ rel: 'alternate', hreflang: iso, href })
-    }
-    // x-default points to the default locale URL (defaultLocale in nuxt.config.ts)
-    const defaultPath = switchLocalePath(DEFAULT_LOCALE) || '/'
-    const defaultHref = new URL(defaultPath, site.url).toString()
-    items.push({ rel: 'alternate', hreflang: 'x-default', href: defaultHref })
-    return items
-  })
 
   const robotsDirective = computed(() => buildRobots(opts))
   const keywordsMeta = computed(() => normaliseKeywords(opts.keywords))
 
+  // Canonical + hreflang are emitted once, app-wide, by @nuxtjs/i18n
+  // (see layouts/default.vue). Here we only add page-specific robots /
+  // keywords meta to avoid duplicate or conflicting link tags.
   useHead(() => {
     const meta: Array<{ name: string; content: string }> = []
     if (robotsDirective.value) meta.push({ name: 'robots', content: robotsDirective.value })
     if (keywordsMeta.value) meta.push({ name: 'keywords', content: keywordsMeta.value })
-    return {
-      link: [
-        { rel: 'canonical', href: canonicalUrl.value },
-        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
-        ...alternateLinks.value
-      ],
-      meta
-    }
+    return { meta }
   })
 
   // Social preview image for OG/Twitter
@@ -78,22 +70,6 @@ export function usePageSeo(opts: PageSeoOptions = {}) {
   })
 
   // Resolve og:locale from the current locale code
-  const currentLocaleObj = computed(() => {
-    const all = Array.isArray(locales.value) ? locales.value : []
-    return (all as Array<any>).find(l => (typeof l === 'string' ? l : l.code) === locale.value)
-  })
-  const ogLocale = computed(() => {
-    const l = currentLocaleObj.value
-    if (!l) return locale.value
-    return typeof l === 'string' ? l : (l.iso || l.code)
-  })
-  const ogLocaleAlternate = computed(() => {
-    const all = Array.isArray(locales.value) ? locales.value : []
-    return (all as Array<any>)
-      .filter(l => (typeof l === 'string' ? l : l.code) !== locale.value)
-      .map(l => (typeof l === 'string' ? l : (l.iso || l.code)))
-  })
-
   type SocialHandles = { twitterSite?: string; twitterCreator?: string }
   const socialHandles = (runtime.public as { social?: SocialHandles }).social
   const twitterSite = opts.twitterSite || socialHandles?.twitterSite || undefined
@@ -112,8 +88,7 @@ export function usePageSeo(opts: PageSeoOptions = {}) {
     ogImageHeight: opts.imageHeight || (socialImage.value ? 630 : undefined),
     ogImageType: opts.imageType || (socialImage.value ? 'image/webp' : undefined),
     ogSiteName: site.name,
-    ogLocale: ogLocale,
-    ogLocaleAlternate: ogLocaleAlternate,
+    // og:locale + og:locale:alternate are emitted by @nuxtjs/i18n.
     twitterCard: opts.twitterCard || 'summary_large_image',
     twitterTitle: pageTitle,
     twitterDescription: pageDescription,

--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { NuxtError } from '#app'
+
+const props = defineProps<{ error: NuxtError }>()
+
+const { t } = useI18n()
+const localePath = useLocalePath()
+
+const isNotFound = computed(() => props.error?.statusCode === 404)
+
+const title = computed(() => (isNotFound.value ? t('error.title_404') : t('error.title_generic')))
+const message = computed(() => (isNotFound.value ? t('error.message_404') : t('error.message_generic')))
+
+useHead(() => ({ title: title.value }))
+
+const handleHome = () => clearError({ redirect: localePath('index') })
+</script>
+
+<template>
+  <NuxtLayout>
+    <div class="container mx-auto flex min-h-[60vh] max-w-screen-md flex-col items-center justify-center px-4 py-16 text-center">
+      <p class="text-7xl font-extrabold tracking-tight text-[var(--color-secondary)]">
+        {{ error?.statusCode || 500 }}
+      </p>
+      <h1 class="mt-4 text-3xl font-bold text-neutral-900 dark:text-neutral-100">
+        {{ title }}
+      </h1>
+      <p class="mt-3 max-w-prose text-neutral-600 dark:text-neutral-400">
+        {{ message }}
+      </p>
+      <button
+        type="button"
+        class="mt-8 inline-flex items-center gap-2 rounded-full bg-[var(--color-secondary)] px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-secondary)] focus-visible:ring-offset-2"
+        @click="handleHome"
+      >
+        {{ t('navigation.back_home') }}
+      </button>
+    </div>
+  </NuxtLayout>
+</template>

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -176,5 +176,11 @@
     "share_native": "Teilen…",
     "copy_link": "Link kopieren",
     "copied": "Link kopiert"
+  },
+  "error": {
+    "title_404": "Seite nicht gefunden",
+    "message_404": "Die gesuchte Seite existiert nicht oder wurde möglicherweise an eine neue Adresse verschoben.",
+    "title_generic": "Etwas ist schiefgelaufen",
+    "message_generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es gleich noch einmal."
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -176,5 +176,11 @@
     "share_native": "Share…",
     "copy_link": "Copy link",
     "copied": "Link copied"
+  },
+  "error": {
+    "title_404": "Page not found",
+    "message_404": "The page you are looking for doesn’t exist or may have moved to a new address.",
+    "title_generic": "Something went wrong",
+    "message_generic": "An unexpected error occurred. Please try again in a moment."
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,10 +1,21 @@
 <script setup lang="ts">
+import { unref } from 'vue'
 import LayoutNavigationBar from '~/components/features/navigation/NavigationBar.vue'
 import LayoutFooter from '~/components/features/footer/Footer.vue'
 
 const route = useRoute()
 const { t } = useI18n()
-const head = useLocaleHead()
+
+// Single source of truth for canonical + hreflang + og:locale across the
+// whole app. Driven by @nuxtjs/i18n (incl. translated blog slugs via
+// useSetI18nParams), so individual composables no longer hand-roll their
+// own canonical/alternate links — that previously produced duplicate /
+// conflicting hreflang tags that Google flagged.
+const head = useLocaleHead({ dir: true, lang: true, seo: true })
+useHead(() => {
+  const h = unref(head)
+  return { link: h?.link ?? [], meta: h?.meta ?? [] }
+})
 // Only set a static <Title> when the route explicitly provides one via meta.
 const routeTitle = computed(() => (route.meta?.title ? t(route.meta.title as string) : null))
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -88,7 +88,10 @@ export default defineNuxtConfig({
             cookieKey: 'i18n_redirected',
             redirectOn: 'root' // recommended
         },
-        baseUrl: 'http://localhost:3000',
+        // Absolute base for i18n-generated canonical + hreflang links. Kept on
+        // the production domain in every environment so the SEO tags Google
+        // sees are always the real URLs (dev never gets indexed anyway).
+        baseUrl: 'https://onelitefeather.net',
     },
     sitemap: {
         xslColumns: [

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -11,15 +11,16 @@ definePageMeta({
   layout: 'default',
 });
 
-const { blog, headLinks, authors } = await useBlogArticle()
+const { blog, authors } = await useBlogArticle()
 const LazySocialMediaShare = defineAsyncComponent(() => import('~/components/features/blog/SocialMediaShare.vue'))
 
 // All Article-level SEO (meta tags, Article JSON-LD, breadcrumbs, OG
 // image) lives in useArticleSeo — keeps this page focused on view code.
+// Canonical + hreflang are emitted app-wide by @nuxtjs/i18n
+// (layouts/default.vue), driven by the translated slugs useBlogArticle
+// publishes via useSetI18nParams.
 const { title } = useArticleSeo(blog, authors)
 
-// Surface canonical + hreflang + alternates from useBlogArticle.
-useHead(() => ({ link: headLinks.value }))
 useHead(() => (blog.value as BlogArticle | null)?.head || {})
 </script>
 

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -11,7 +11,7 @@ definePageMeta({
   layout: 'default',
 });
 
-const { blog, headLinks, authors } = useBlogArticle()
+const { blog, headLinks, authors } = await useBlogArticle()
 const LazySocialMediaShare = defineAsyncComponent(() => import('~/components/features/blog/SocialMediaShare.vue'))
 
 // All Article-level SEO (meta tags, Article JSON-LD, breadcrumbs, OG


### PR DESCRIPTION
## Summary

This PR refactors SEO tag generation to use @nuxtjs/i18n's built-in canonical and hreflang support instead of hand-rolling duplicate logic across multiple composables. It also fixes blog article language switching by publishing per-locale slugs through `useSetI18nParams`, and adds proper error page handling for missing/unreleased articles.

## Key Changes

- **Centralized SEO generation**: Moved canonical + hreflang + og:locale generation to `layouts/default.vue` using `useLocaleHead()` from @nuxtjs/i18n, eliminating duplicate link tag generation in `usePageSeo` and `useBlogArticle`
- **Blog slug translation support**: Added `useSetI18nParams()` integration in `useBlogArticle` to publish translated slugs per locale, enabling `<SwitchLocalePathLink>` to resolve correct localized URLs instead of naively reusing the current slug
- **Improved slug resolution**: Implemented `slugFromUrl()` and `localeCodeFromHreflang()` helpers to extract and map slugs from front-matter `alternates` and `translationKey` cross-collection lookups
- **Error page handling**: Created `error.vue` component with proper 404/generic error states; changed `useBlogArticle` to return a marker instead of throwing, then raise a fatal error after data resolves for reliable SSR error page rendering
- **Async composable**: Made `useBlogArticle` async and awaited in page component to ensure data resolves before rendering
- **Language selector refactor**: Updated `LanguageSelector.vue` to use `<SwitchLocalePathLink>` instead of manual `setLocale` + `navigateTo`, delegating navigation to the i18n component which now handles translated slugs
- **Config update**: Changed `nuxt.config.ts` baseUrl to production domain so SEO tags always reflect real URLs across all environments

## Implementation Details

- Removed `alternateLanguages` and `headLinks` computed refs from `useBlogArticle` — these are now generated app-wide by @nuxtjs/i18n
- The `publishLocaleParams()` function in `useBlogArticle` updates i18n's internal route params whenever article translations are resolved, making the canonical/hreflang tags automatically reflect the correct localized slugs
- Error handling now distinguishes between missing articles (404) and other failures, with proper HTTP status codes during SSR
- Removed unused `resolveHreflang()` and `HeadLink` type; simplified `usePageSeo` to only handle page-specific robots/keywords meta

https://claude.ai/code/session_01QsCtq62jJ1pfbxJfMKFm1y