### PR TITLE
fix(seo-check): skip mock query on sitemap endpoints (unblocks sitemap 7.6 bump)

### DIFF
--- a/scripts/seo-check.mjs
+++ b/scripts/seo-check.mjs
@@ -71,13 +71,21 @@ const colorise = (level, text) => {
   return `${codes[level] || ''}${text}\x1b[0m`
 }
 
+// @nuxtjs/sitemap >= 7.5 serves an empty 204 (and a meta-refresh instead of a
+// 307) whenever the sitemap endpoints are requested with *any* query string,
+// so the mock-prod query must not be appended to sitemap URLs. The sitemap is
+// environment-independent here anyway; only robots.txt and page meta need the
+// production mock.
+const isSitemapPath = (pathname) =>
+  /^\/(sitemap[^/]*\.xml|sitemap_index\.xml|__sitemap__\/)/i.test(pathname)
+
 /**
  * Builds a URL relative to BASE and adds the dev mock-prod query when
  * targeting localhost so we exercise the production robots/sitemap path.
  */
 const buildUrl = (path) => {
   const url = new URL(path, BASE)
-  if (USE_MOCK && !url.searchParams.has('mockProductionEnv')) {
+  if (USE_MOCK && !isSitemapPath(url.pathname) && !url.searchParams.has('mockProductionEnv')) {
     url.searchParams.set('mockProductionEnv', '')
   }
   return url


### PR DESCRIPTION
## Problem

The Renovate PRs that bump **@nuxtjs/sitemap** to `7.6.0` (#123) and **@nuxtjs/seo** to `3.4.0` (#122, which bundles sitemap 7.6.0) both fail the **"Meta + sitemap + robots"** CI gate.

Root cause is a behaviour change in **@nuxtjs/sitemap ≥ 7.5**:

- `7.4.11`: sitemap endpoints ignored query strings and returned content.
- `7.6.0`: any query string on a sitemap endpoint yields an empty **HTTP 204** (`?foo=bar` → 204, no query → 200), and `/sitemap.xml?…` answers with an HTML meta-refresh instead of a `307` redirect.

`scripts/seo-check.mjs` appends `?mockProductionEnv` to **every** localhost request (to force the production robots/sitemap path out of the dev no-index lock). With 7.6.0 that query makes the sitemap look empty → 9 errors.

Verified locally: the failure reproduces on both #123 (sitemap alone) and #122 (seo bundle); it is not a lockfile/flaky issue.

## Fix

Skip the `?mockProductionEnv` query for sitemap URLs only (`/sitemap*.xml`, `/sitemap_index.xml`, `/__sitemap__/*`). The sitemap output is environment-independent here — verified the no-mock sitemap is fully populated (8 URLs per locale, correct redirect chain). robots.txt and page-meta checks still use the production mock, so coverage is unchanged.

## Validation

Ran the patched `scripts/seo-check.mjs` against a local dev server built with **@nuxtjs/sitemap 7.6.0**:

```
Summary: 0 error(s), 0 warning(s), 10 route(s) checked.
```

(Previously: 9 errors — empty sitemap + all indexable routes missing.)

## Follow-up

Once this lands, #123 and #122 should be rebased and will pass the SEO gate. #116 (@nuxt/content) is unrelated and unaffected.

## Test plan

- [ ] CI "Meta + sitemap + robots" passes on this branch
- [ ] After merge, rebase #123 → SEO gate green → merge
- [ ] After merge, rebase #122 → SEO gate green → merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01S94yKS6dFWg9RBQi3Um4ZM)_