### PR TITLE
Expand team ranks and update team member profiles

### DIFF
--- a/components/features/team/OpenPositionCard.vue
+++ b/components/features/team/OpenPositionCard.vue
@@ -19,14 +19,14 @@ const { t } = useI18n()
 
 <template>
   <li class="shrink-0 w-72">
-    <div class="flex h-full flex-col rounded-2xl border border-dashed border-brand-400/70 dark:border-brand-500/60 bg-brand-50/40 dark:bg-brand-950/20 p-4">
+    <div class="flex h-full flex-col rounded-2xl border border-dashed border-primary/40 dark:border-secondary/50 bg-primary/5 dark:bg-primary/10 p-4">
       <div class="flex items-center gap-4">
         <span
-          class="flex h-16 w-16 items-center justify-center rounded-xl bg-brand-100 dark:bg-brand-900/40 text-brand-600 dark:text-brand-300 text-2xl font-bold"
+          class="flex h-16 w-16 items-center justify-center rounded-xl bg-primary/10 dark:bg-primary/25 text-primary dark:text-secondary text-2xl font-bold"
           aria-hidden="true"
         >+</span>
         <div class="min-w-0">
-          <p class="text-xs font-semibold uppercase tracking-wide text-brand-600 dark:text-brand-400">
+          <p class="text-xs font-semibold uppercase tracking-wide text-primary dark:text-secondary">
             {{ t('team.open_position.badge') }}
           </p>
           <h3 class="truncate text-lg font-semibold text-gray-900 dark:text-gray-100">{{ props.role }}</h3>
@@ -37,7 +37,7 @@ const { t } = useI18n()
         :href="props.applyUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="mt-4 inline-flex items-center justify-center gap-2 rounded-lg bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+        class="mt-4 inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         :aria-label="t('team.open_position.apply_aria', { role: props.role })"
       >
         <FontAwesomeIcon :icon="faDiscord" class="h-4 w-4" aria-hidden="true" />

--- a/composables/useTeamProfile.ts
+++ b/composables/useTeamProfile.ts
@@ -23,10 +23,10 @@ export function useTeamProfile(slugOverride?: string) {
 
   const avatarSrc = computed(() => {
     const m = member.value
-    if (!m) return '/favicon.ico'
+    if (!m) return '/favicon.svg'
     if (m.avatarUrl) return m.avatarUrl
     if (m.mcName) return `https://mc-heads.net/avatar/${encodeURIComponent(m.mcName)}/256`
-    return '/favicon.ico'
+    return '/favicon.svg'
   })
 
   return {

--- a/content/team/de/home.json
+++ b/content/team/de/home.json
@@ -10,13 +10,12 @@
       "href": "/de/team/themeinerlp"
     },
     {
-      "id": "open-admin",
-      "name": "Dein Platz?",
-      "role": "Administration",
+      "id": "selenretterin",
+      "name": "Selenretterin",
+      "slug": "selenretterin",
       "rank": "admin",
-      "slogan": "Hilf mit, das Netzwerk zu betreiben und zu gestalten.",
-      "openPosition": true,
-      "applyUrl": "https://1lf.link/discord"
+      "slogan": "aka OneLiteFeather",
+      "href": "/de/team/selenretterin"
     },
     {
       "id": "joltra",

--- a/content/team/en/home.json
+++ b/content/team/en/home.json
@@ -10,13 +10,12 @@
       "href": "/en/team/themeinerlp"
     },
     {
-      "id": "open-admin",
-      "name": "Your seat?",
-      "role": "Administration",
+      "id": "selenretterin",
+      "name": "Selenretterin",
+      "slug": "selenretterin",
       "rank": "admin",
-      "slogan": "Help run and shape the network.",
-      "openPosition": true,
-      "applyUrl": "https://1lf.link/discord"
+      "slogan": "aka OneLiteFeather",
+      "href": "/en/team/selenretterin"
     },
     {
       "id": "joltra",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -4,6 +4,7 @@
     "toggle_mobile_menu": "Mobile Menü umschalten",
     "home": "Startseite",
     "back_home": "Zur Startseite zurück",
+    "back_team": "Zum Team zurück",
     "main": "Hauptnavigation",
     "mobile": "Mobile Navigation",
     "bottom": "Untere Navigation",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -90,8 +90,11 @@
     },
     "ranks": {
       "admin": "Administration",
+      "teamassist": "Teamassistenz",
       "content": "Content",
-      "moderation": "Moderation"
+      "moderation": "Moderation",
+      "media": "Social Media",
+      "lite": "Lite"
     },
     "open_position": {
       "badge": "Offene Stelle",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -4,6 +4,7 @@
     "toggle_mobile_menu": "Toggle mobile menu",
     "home": "Home",
     "back_home": "Back to home",
+    "back_team": "Back to team",
     "main": "Main navigation",
     "mobile": "Mobile navigation",
     "bottom": "Bottom navigation",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -90,8 +90,11 @@
     },
     "ranks": {
       "admin": "Administration",
+      "teamassist": "Team Assistance",
       "content": "Content",
-      "moderation": "Moderation"
+      "moderation": "Moderation",
+      "media": "Social Media",
+      "lite": "Lite"
     },
     "open_position": {
       "badge": "Open position",

--- a/pages/team/[slug].vue
+++ b/pages/team/[slug].vue
@@ -71,11 +71,11 @@ useSchemaOrg(() => {
 <template>
   <main class="mx-auto max-w-4xl px-4 py-10">
     <NuxtLink
-      to="/"
+      :to="`/${locale}/team`"
       class="text-sm text-primary dark:text-primary/80 hover:underline"
-      :aria-label="$t('navigation.back_home')"
+      :aria-label="$t('navigation.back_team')"
     >
-      ← {{ $t('navigation.home') }}
+      ← {{ $t('navigation.team') }}
     </NuxtLink>
     <div v-if="member" class="mt-4 rounded-2xl border border-zinc-200/70 dark:border-zinc-800/80 bg-white/90 dark:bg-zinc-900/80 p-6 md:p-8">
       <div class="flex items-start gap-5">

--- a/types/team.ts
+++ b/types/team.ts
@@ -7,12 +7,26 @@ export type TeamDocument =
 export type TeamMember =
   NonNullable<TeamDocument['members']>[number]
 
-export type TeamRank = 'admin' | 'content' | 'moderation'
+export type TeamRank =
+  | 'admin'
+  | 'teamassist'
+  | 'content'
+  | 'moderation'
+  | 'media'
+  | 'lite'
 
-/** Display order of rank sections on the team page. */
+/**
+ * Display order of rank sections on the team page, most senior first.
+ * Mirrors the LuckPerms inheritance path (administrator → teamassist →
+ * content → moderator → media → lite); `default` is a regular player and
+ * not a team rank.
+ */
 export const TEAM_RANK_ORDER: TeamRank[] = [
   'admin',
+  'teamassist',
   'content',
-  'moderation'
+  'moderation',
+  'media',
+  'lite'
 ]
 


### PR DESCRIPTION
## Summary
This PR expands the team rank system to include four new roles (teamassist, media, lite) and updates team member data, including adding Selenretterin as an admin member and removing the open admin position placeholder.

## Key Changes

- **Team Rank System Expansion**
  - Added four new team ranks: `teamassist`, `media`, and `lite` to the `TeamRank` type
  - Updated `TEAM_RANK_ORDER` to reflect the LuckPerms inheritance hierarchy (admin → teamassist → content → moderation → media → lite)
  - Enhanced documentation to clarify the rank ordering and its relationship to LuckPerms

- **Team Member Updates**
  - Replaced the "open-admin" placeholder position with Selenretterin as a confirmed admin member in both English and German team pages
  - Added proper profile links (`href`/`slug`) for the new team member

- **Internationalization**
  - Added translations for new team ranks in both English and German locales
  - Added new navigation string `back_team` for team member profile pages

- **UI/Component Updates**
  - Updated `OpenPositionCard.vue` to use semantic color tokens (`primary`/`secondary`) instead of hardcoded brand colors for better theme consistency
  - Fixed favicon references from `.ico` to `.svg` in `useTeamProfile.ts`

- **Navigation Improvements**
  - Updated team member profile page to link back to the team page instead of home
  - Changed back button label to use the appropriate team navigation string

https://claude.ai/code/session_01Weib7o4eabFj5hJrFqWyPN