### PR TITLE
Refactor team avatar handling with centralized utility

### DIFF
--- a/components/features/blog/page/FeaturedTeamMembers.vue
+++ b/components/features/blog/page/FeaturedTeamMembers.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { NuxtLink } from '#components'
+import { teamAvatarUrl } from '~/utils/teamAvatar'
 
 const props = defineProps<{ slugs: string[] }>()
 
@@ -30,16 +31,19 @@ const members = computed(() => props.slugs
           :to="`/${locale}/team/${m.slug}`"
           class="inline-flex items-center gap-3 rounded-xl border border-neutral-200 dark:border-neutral-800 px-3 py-2 hover:bg-neutral-50 dark:hover:bg-neutral-800/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
         >
-          <img
-            v-if="m.mcName || m.avatarUrl"
-            :src="m.avatarUrl || `https://mc-heads.net/avatar/${encodeURIComponent(m.mcName as string)}/64`"
+          <NuxtImg
+            :src="teamAvatarUrl({ mcName: m.mcName, slug: m.slug, avatarUrl: m.avatarUrl }, 64)"
             :alt="t('team.avatar_alt', { name: m.name })"
             width="32"
             height="32"
+            fit="cover"
+            format="avif,webp"
+            quality="80"
+            densities="x1 x2"
             class="h-8 w-8 rounded-lg object-cover"
             loading="lazy"
             decoding="async"
-          >
+          />
           <span class="min-w-0">
             <span class="block text-sm font-semibold text-neutral-900 dark:text-neutral-100">{{ m.name }}</span>
             <span v-if="m.role" class="block text-xs text-neutral-600 dark:text-neutral-400">{{ m.role }}</span>

--- a/components/features/home/team/TeamMemberCard.vue
+++ b/components/features/home/team/TeamMemberCard.vue
@@ -3,12 +3,14 @@ import { useI18n } from 'vue-i18n'
 import { NuxtLink } from '#components'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
+import { teamAvatarUrl } from '~/utils/teamAvatar'
 
 type Props = {
   name: string
   role: string
   slogan?: string
   mcName?: string
+  slug?: string
   avatarUrl?: string
   href?: string
 }
@@ -16,6 +18,7 @@ type Props = {
 const props = withDefaults(defineProps<Props>(), {
   slogan: undefined,
   mcName: undefined,
+  slug: undefined,
   avatarUrl: undefined,
   href: undefined
 })
@@ -24,12 +27,13 @@ const { t } = useI18n()
 
 const profileHref = computed(() => props.href || (props.mcName ? `/team/${encodeURIComponent(props.mcName.toLowerCase())}` : undefined))
 
-const avatarSrc = computed(() => {
-  if (props.avatarUrl) return props.avatarUrl
-  if (props.mcName) return `https://mc-heads.net/avatar/${encodeURIComponent(props.mcName)}/128`
-  // Default to Steve's head for placeholder/empty slots
-  return 'https://mc-heads.net/avatar/Steve/128'
-})
+// Upstream PNG (mc-heads.net at 128px) is routed through the Cloudflare
+// Images provider, which reships it as AVIF/WebP at the displayed 64px box.
+const avatarSrc = computed(() => teamAvatarUrl({
+  mcName: props.mcName,
+  slug: props.slug,
+  avatarUrl: props.avatarUrl
+}, 128))
 
 const ariaLabel = computed(() => t('team.card_aria', { name: props.name, role: props.role }))
 </script>
@@ -43,11 +47,15 @@ const ariaLabel = computed(() => t('team.card_aria', { name: props.name, role: p
       class="group block h-full rounded-2xl border border-zinc-200/70 dark:border-zinc-800/80 bg-white/90 dark:bg-zinc-900/80 p-4 backdrop-blur supports-[backdrop-filter]:bg-white/70 supports-[backdrop-filter]:dark:bg-zinc-900/60 hover:shadow-lg transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
     >
       <div class="flex items-center gap-4">
-        <img
+        <NuxtImg
           :src="avatarSrc"
           :alt="t('team.avatar_alt', { name })"
           width="64"
           height="64"
+          fit="cover"
+          format="avif,webp"
+          quality="80"
+          densities="x1 x2"
           class="h-16 w-16 rounded-xl ring-1 ring-black/5 dark:ring-white/5 object-cover bg-zinc-100 dark:bg-zinc-800"
           loading="lazy"
           decoding="async"

--- a/components/features/home/team/TeamMembers.vue
+++ b/components/features/home/team/TeamMembers.vue
@@ -119,6 +119,7 @@ const onWheel = (e: WheelEvent) => {
           :role="m.role"
           :slogan="m.slogan"
           :mc-name="m.mcName"
+          :slug="m.slug"
           :avatar-url="m.avatarUrl"
           :href="m.href ?? (m.slug ? `/team/${m.slug}` : undefined)"
         />

--- a/components/features/team/TeamRankSection.vue
+++ b/components/features/team/TeamRankSection.vue
@@ -29,6 +29,7 @@ const profileHref = (slug?: string) => slug ? `/${locale.value}/team/${slug}` : 
         :role="m.role || rankLabel"
         :slogan="m.slogan"
         :mc-name="m.mcName"
+        :slug="m.slug"
         :avatar-url="m.avatarUrl"
         :href="profileHref(m.slug)"
       />

--- a/composables/useTeamProfile.ts
+++ b/composables/useTeamProfile.ts
@@ -1,6 +1,7 @@
 import { useContentRepository } from '~/composables/useContentRepository'
 import type { Locale } from '~/utils/content/collections'
 import type { TeamDocument, TeamMember } from '~/types/team'
+import { teamAvatarUrl } from '~/utils/teamAvatar'
 
 export function useTeamProfile(slugOverride?: string) {
   const route = useRoute()
@@ -21,12 +22,13 @@ export function useTeamProfile(slugOverride?: string) {
     return (list as TeamMember[]).find((m) => m.slug === slug.value) || null
   })
 
+  // Profile hero renders the head at 96px in a 2x density box. Requesting
+  // a 256px upstream render leaves headroom for retina and lets the
+  // Cloudflare Images provider re-encode to AVIF/WebP at smaller sizes.
   const avatarSrc = computed(() => {
     const m = member.value
     if (!m) return '/favicon.svg'
-    if (m.avatarUrl) return m.avatarUrl
-    if (m.mcName) return `https://mc-heads.net/avatar/${encodeURIComponent(m.mcName)}/256`
-    return '/favicon.svg'
+    return teamAvatarUrl({ mcName: m.mcName, slug: m.slug, avatarUrl: m.avatarUrl }, 256)
   })
 
   return {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -130,6 +130,10 @@ export default defineNuxtConfig({
         format: ['avif', 'webp'],
         // Slightly lower default quality to trim payloads without obvious visual loss.
         quality: 75,
+        // Allow the Cloudflare Images pipeline to transform third-party origins
+        // we explicitly trust. Minecraft head renders come from mc-heads.net and
+        // are reshipped as AVIF/WebP via img.onelitefeather.net.
+        domains: ['mc-heads.net'],
         // The screen sizes predefined by `@nuxt/image`:
         screens: {
             xs: 320,
@@ -276,6 +280,7 @@ export default defineNuxtConfig({
         },
         image: {
             format: ['avif', 'webp'],
+            domains: ['mc-heads.net'],
             cloudflare: {
                 baseURL: 'https://img.onelitefeather.net',
             }

--- a/pages/team/[slug].vue
+++ b/pages/team/[slug].vue
@@ -79,7 +79,17 @@ useSchemaOrg(() => {
     </NuxtLink>
     <div v-if="member" class="mt-4 rounded-2xl border border-zinc-200/70 dark:border-zinc-800/80 bg-white/90 dark:bg-zinc-900/80 p-6 md:p-8">
       <div class="flex items-start gap-5">
-        <img :src="avatarSrc" :alt="t('team.avatar_alt', { name: member.name })" width="96" height="96" class="h-24 w-24 rounded-2xl ring-1 ring-black/5 dark:ring-white/5 object-cover" >
+        <NuxtImg
+          :src="avatarSrc"
+          :alt="t('team.avatar_alt', { name: member.name })"
+          width="96"
+          height="96"
+          fit="cover"
+          format="avif,webp"
+          quality="80"
+          densities="x1 x2"
+          class="h-24 w-24 rounded-2xl ring-1 ring-black/5 dark:ring-white/5 object-cover"
+        />
         <div>
           <div class="flex flex-wrap items-center gap-2">
             <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">{{ member.name }}</h1>

--- a/utils/teamAvatar.ts
+++ b/utils/teamAvatar.ts
@@ -1,0 +1,38 @@
+import type { TeamMember } from '~/types/team'
+
+/**
+ * Source host for Minecraft head renders. Must be allow-listed in
+ * `image.domains` (see `nuxt.config.ts`) so the Cloudflare Images
+ * provider can transform/optimise the upstream PNG.
+ */
+const MC_HEADS_HOST = 'https://mc-heads.net/avatar'
+
+/** Steve fallback for open positions and members without an MC identity. */
+const FALLBACK_MC_NAME = 'Steve'
+
+/**
+ * Resolves the Minecraft username used to fetch a head render. Falls back
+ * to the team slug because, for the OneLiteFeather roster, slugs equal the
+ * MC name for the majority of entries. `mc-heads.net` returns the Steve
+ * head for unknown names, which keeps the layout intact for the few slugs
+ * that aren't valid usernames.
+ */
+export function mcUsernameOf(member: Pick<TeamMember, 'mcName' | 'slug'>): string {
+  return member.mcName || member.slug || FALLBACK_MC_NAME
+}
+
+/**
+ * Upstream avatar URL for a team member. The Nuxt Image Cloudflare
+ * provider rewrites this through `img.onelitefeather.net/cdn-cgi/image/...`
+ * so the browser receives AVIF/WebP at the requested size.
+ *
+ * `size` is the upstream render size in pixels. Pass the largest display
+ * size needed; `NuxtImg`'s `sizes`/density handles smaller variants.
+ */
+export function teamAvatarUrl(
+  member: Pick<TeamMember, 'mcName' | 'slug' | 'avatarUrl'>,
+  size = 128
+): string {
+  if (member.avatarUrl) return member.avatarUrl
+  return `${MC_HEADS_HOST}/${encodeURIComponent(mcUsernameOf(member))}/${size}`
+}


### PR DESCRIPTION
## Summary
Centralizes team member avatar URL generation logic into a reusable utility function and upgrades image components to use NuxtImg for automatic format optimization (AVIF/WebP) and responsive sizing.

## Key Changes
- **New utility module** (`utils/teamAvatar.ts`): Extracted avatar URL generation logic into `teamAvatarUrl()` and `mcUsernameOf()` functions with fallback handling for members without custom avatars
- **Image optimization**: Replaced raw `<img>` tags with `<NuxtImg>` components across team member displays to enable:
  - Automatic format conversion to AVIF/WebP via Cloudflare Images
  - Responsive density handling (x1, x2)
  - Quality optimization (80% for team cards, 75% default)
- **Configuration updates**: Added `mc-heads.net` to image provider domain allowlist in `nuxt.config.ts` to enable Cloudflare Images transformation of third-party Minecraft head renders
- **Component updates**: Passed `slug` prop to `TeamMemberCard` to enable fallback avatar resolution when `mcName` is unavailable

## Implementation Details
- Avatar resolution follows priority: custom `avatarUrl` → `mcName` → `slug` → "Steve" fallback
- Upstream PNG sizes are strategically chosen (128px for cards, 256px for profiles) to provide headroom for Cloudflare's re-encoding to smaller display sizes
- All team member display components now benefit from centralized avatar logic and automatic image optimization

https://claude.ai/code/session_01V9AfghtzBaP5u7foqCRTyK