### PR TITLE
feat(team): roster refresh, application FAQ, role chips

### DIFF
--- a/components/OgImage/TeamMember.satori.vue
+++ b/components/OgImage/TeamMember.satori.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+defineProps<{
+  name?: string
+  description?: string
+  roleText?: string
+  rankLabel?: string
+  avatarUrl?: string
+}>()
+</script>
+
+<template>
+  <div
+    class="relative h-full w-full flex items-center text-white overflow-hidden"
+    style="background: linear-gradient(135deg, #11162a 0%, #2A388F 55%, #91268F 100%);"
+  >
+    <!-- Top-right brand wordmark -->
+    <div class="absolute top-12 right-16 flex items-center gap-3 text-[26px] font-semibold tracking-tight opacity-90">
+      <div
+        class="flex items-center justify-center rounded-full"
+        style="width: 44px; height: 44px; background: rgba(255,255,255,0.12);"
+      >
+        <span class="text-[22px]">OL</span>
+      </div>
+      <span>OneLiteFeather</span>
+    </div>
+
+    <!-- Avatar block (left) -->
+    <div class="flex items-center justify-center" style="margin-left: 80px;">
+      <div
+        class="flex items-center justify-center"
+        style="width: 320px; height: 320px; background: rgba(255,255,255,0.06); border: 2px solid rgba(255,255,255,0.18); border-radius: 32px; box-shadow: 0 24px 60px -16px rgba(0,0,0,0.45);"
+      >
+        <img
+          v-if="avatarUrl"
+          :src="avatarUrl"
+          width="256"
+          height="256"
+          style="image-rendering: pixelated; border-radius: 24px;"
+        />
+      </div>
+    </div>
+
+    <!-- Text block (right) -->
+    <div class="flex flex-col" style="margin-left: 60px; max-width: 660px;">
+      <div
+        v-if="rankLabel"
+        class="text-[22px] font-semibold uppercase tracking-[0.18em]"
+        style="color: #27A9E1;"
+      >
+        {{ rankLabel }}
+      </div>
+
+      <h1
+        class="text-[88px] font-bold leading-[1.02] tracking-tight mt-3"
+        style="display: block; line-clamp: 2; text-overflow: ellipsis; text-wrap: balance;"
+      >
+        {{ name }}
+      </h1>
+
+      <p
+        v-if="description"
+        class="text-[28px] leading-snug mt-6"
+        style="color: rgba(255,255,255,0.85); display: block; line-clamp: 3; text-overflow: ellipsis;"
+      >
+        {{ description }}
+      </p>
+
+      <p
+        v-if="roleText"
+        class="text-[22px] mt-5"
+        style="color: rgba(255,255,255,0.65); display: block; line-clamp: 1; text-overflow: ellipsis;"
+      >
+        {{ roleText }}
+      </p>
+    </div>
+
+    <!-- Accent bar bottom -->
+    <div
+      class="absolute bottom-0 left-0 right-0"
+      style="height: 8px; background: linear-gradient(90deg, #EC008B 0%, #F7931D 50%, #27A9E1 100%);"
+    />
+  </div>
+</template>

--- a/components/features/blog/page/FeaturedTeamMembers.vue
+++ b/components/features/blog/page/FeaturedTeamMembers.vue
@@ -2,6 +2,7 @@
 import { useI18n } from 'vue-i18n'
 import { NuxtLink } from '#components'
 import { teamAvatarUrl } from '~/utils/teamAvatar'
+import { toRoleString } from '~/utils/teamRoles'
 
 const props = defineProps<{ slugs: string[] }>()
 
@@ -46,7 +47,7 @@ const members = computed(() => props.slugs
           />
           <span class="min-w-0">
             <span class="block text-sm font-semibold text-neutral-900 dark:text-neutral-100">{{ m.name }}</span>
-            <span v-if="m.role" class="block text-xs text-neutral-600 dark:text-neutral-400">{{ m.role }}</span>
+            <span v-if="toRoleString(m.role)" class="block text-xs text-neutral-600 dark:text-neutral-400">{{ toRoleString(m.role) }}</span>
           </span>
         </NuxtLink>
       </li>

--- a/components/features/home/team/TeamMemberCard.vue
+++ b/components/features/home/team/TeamMemberCard.vue
@@ -3,11 +3,13 @@ import { useI18n } from 'vue-i18n'
 import { NuxtLink } from '#components'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
+import UiChip from '~/components/base/Chip.vue'
 import { teamAvatarUrl } from '~/utils/teamAvatar'
+import { toRoleList, toRoleString } from '~/utils/teamRoles'
 
 type Props = {
   name: string
-  role: string
+  role?: string | string[]
   slogan?: string
   mcName?: string
   slug?: string
@@ -16,6 +18,7 @@ type Props = {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  role: undefined,
   slogan: undefined,
   mcName: undefined,
   slug: undefined,
@@ -35,7 +38,9 @@ const avatarSrc = computed(() => teamAvatarUrl({
   avatarUrl: props.avatarUrl
 }, 128))
 
-const ariaLabel = computed(() => t('team.card_aria', { name: props.name, role: props.role }))
+const roleChips = computed(() => toRoleList(props.role))
+const roleAriaText = computed(() => toRoleString(props.role))
+const ariaLabel = computed(() => t('team.card_aria', { name: props.name, role: roleAriaText.value }))
 </script>
 
 <template>
@@ -62,8 +67,16 @@ const ariaLabel = computed(() => t('team.card_aria', { name: props.name, role: p
         />
         <div class="min-w-0">
           <h3 class="truncate text-lg font-semibold text-gray-900 dark:text-gray-100">{{ name }}</h3>
-          <p class="truncate text-sm text-gray-600 dark:text-gray-400">{{ role }}</p>
         </div>
+      </div>
+      <div v-if="roleChips.length" class="mt-3 flex flex-wrap gap-2">
+        <UiChip
+          v-for="chip in roleChips"
+          :key="chip"
+          :label="chip"
+          variant="outlined"
+          as="span"
+        />
       </div>
       <p v-if="slogan" class="mt-3 line-clamp-3 text-sm text-gray-700 dark:text-gray-300">“{{ slogan }}”</p>
       <p v-if="profileHref" class="mt-3 inline-flex items-center gap-1 text-sm font-medium text-brand-600 dark:text-brand-400">

--- a/components/features/home/team/TeamMembers.vue
+++ b/components/features/home/team/TeamMembers.vue
@@ -2,6 +2,7 @@
 import TeamMemberCard from './TeamMemberCard.vue'
 import { useI18n } from 'vue-i18n'
 import type { TeamMember } from '~/types/team'
+import { toRoleList } from '~/utils/teamRoles'
 
 type Props = {
   title?: string
@@ -23,7 +24,10 @@ const selectedRole = ref<string>('')
 const visibleCount = ref<number | null>(props.limit)
 
 const roles = computed(() => {
-  const set = new Set(props.members.map(m => m.role).filter(Boolean))
+  const set = new Set<string>()
+  for (const m of props.members) {
+    for (const r of toRoleList(m.role)) set.add(r)
+  }
   return Array.from(set)
 })
 
@@ -31,7 +35,7 @@ const filtered = computed(() => {
   const q = query.value.trim().toLowerCase()
   const r = selectedRole.value
   let list = props.members
-  if (r) list = list.filter(m => m.role === r)
+  if (r) list = list.filter(m => toRoleList(m.role).includes(r))
   if (q) list = list.filter(m => m.name.toLowerCase().includes(q))
   return list
 })

--- a/components/features/team/OpenPositionCard.vue
+++ b/components/features/team/OpenPositionCard.vue
@@ -2,19 +2,33 @@
 import { useI18n } from 'vue-i18n'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faDiscord } from '@fortawesome/free-brands-svg-icons'
+import { faHandHoldingHeart } from '@fortawesome/free-solid-svg-icons'
+import { toRoleString } from '~/utils/teamRoles'
 
 type Props = {
-  role: string
+  role: string | string[]
   slogan?: string
   applyUrl?: string
+  applyVia?: 'discord' | 'opencollective'
 }
 
 const props = withDefaults(defineProps<Props>(), {
   slogan: undefined,
-  applyUrl: 'https://1lf.link/discord'
+  applyUrl: 'https://1lf.link/discord',
+  applyVia: 'discord'
 })
 
 const { t } = useI18n()
+
+const roleText = computed(() => toRoleString(props.role))
+const isOpenCollective = computed(() => props.applyVia === 'opencollective')
+const icon = computed(() => isOpenCollective.value ? faHandHoldingHeart : faDiscord)
+const applyLabel = computed(() => isOpenCollective.value
+  ? t('team.open_position.apply_opencollective')
+  : t('team.open_position.apply'))
+const applyAria = computed(() => isOpenCollective.value
+  ? t('team.open_position.apply_aria_opencollective', { role: roleText.value })
+  : t('team.open_position.apply_aria', { role: roleText.value }))
 </script>
 
 <template>
@@ -29,19 +43,19 @@ const { t } = useI18n()
           <p class="text-xs font-semibold uppercase tracking-wide text-primary dark:text-secondary">
             {{ t('team.open_position.badge') }}
           </p>
-          <h3 class="truncate text-lg font-semibold text-gray-900 dark:text-gray-100">{{ props.role }}</h3>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 break-words">{{ roleText }}</h3>
         </div>
       </div>
-      <p v-if="props.slogan" class="mt-3 line-clamp-3 text-sm text-gray-700 dark:text-gray-300">{{ props.slogan }}</p>
+      <p v-if="props.slogan" class="mt-3 text-sm text-gray-700 dark:text-gray-300">{{ props.slogan }}</p>
       <a
         :href="props.applyUrl"
         target="_blank"
         rel="noopener noreferrer"
         class="mt-4 inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-        :aria-label="t('team.open_position.apply_aria', { role: props.role })"
+        :aria-label="applyAria"
       >
-        <FontAwesomeIcon :icon="faDiscord" class="h-4 w-4" aria-hidden="true" />
-        {{ t('team.open_position.apply') }}
+        <FontAwesomeIcon :icon="icon" class="h-4 w-4" aria-hidden="true" />
+        {{ applyLabel }}
       </a>
     </div>
   </li>

--- a/components/features/team/TeamFaqSection.vue
+++ b/components/features/team/TeamFaqSection.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { extractPlainText } from '~/utils/content'
+
+const { t } = useI18n()
+const { items } = useTeamFaqContent()
+
+const detailsClass = [
+  'group rounded-xl border border-neutral-200 dark:border-neutral-800',
+  'bg-white dark:bg-neutral-900/60 px-4 py-3 open:shadow-sm',
+  'transition-shadow'
+].join(' ')
+
+const summaryClass = [
+  'flex cursor-pointer list-none items-center justify-between gap-4',
+  'text-base font-semibold text-neutral-900 dark:text-neutral-100',
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md'
+].join(' ')
+
+const toggleClass = [
+  'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full',
+  'bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300',
+  'transition-transform group-open:rotate-45'
+].join(' ')
+
+const proseClass = [
+  'prose prose-sm md:prose-base prose-neutral dark:prose-invert max-w-none mt-3', 'prose-a:text-primary prose-a:underline-offset-2 prose-a:hover:underline'
+].join(' ')
+
+// Extra FAQPage schema scoped to the team page; Google currently restricts
+// FAQ rich results to authoritative sources, but other crawlers (Bing,
+// DuckDuckGo, AI assistants) still pick it up. Plain-text answers only,
+// so we strip the MDC AST down.
+useSchemaOrg(() => {
+  if (!items.value.length) return []
+  return [
+    {
+      '@type': 'FAQPage',
+      mainEntity: items.value.map((entry) => ({
+        '@type': 'Question' as const,
+        name: entry.question,
+        acceptedAnswer: {
+          '@type': 'Answer' as const,
+          text: extractPlainText(entry.body, 500)
+        }
+      }))
+    }
+  ]
+})
+</script>
+
+<template>
+  <section
+    v-if="items.length"
+    class="mt-12 md:mt-16"
+    :aria-labelledby="'team-faq-heading'"
+  >
+    <header class="mb-6 text-center">
+      <h2
+        id="team-faq-heading"
+        class="text-2xl md:text-3xl font-bold tracking-tight text-neutral-900 dark:text-neutral-100"
+      >
+        {{ t('team.faq.section_title') }}
+      </h2>
+      <p class="mt-2 text-sm md:text-base text-neutral-600 dark:text-neutral-400">
+        {{ t('team.faq.section_subtitle') }}
+      </p>
+    </header>
+
+    <div class="space-y-3">
+      <details
+        v-for="entry in items"
+        :key="entry.key"
+        :class="detailsClass"
+      >
+        <summary :class="summaryClass">
+          <span>{{ entry.question }}</span>
+          <span :class="toggleClass" aria-hidden="true">+</span>
+        </summary>
+        <div :class="proseClass">
+          <ContentRenderer :value="entry" />
+        </div>
+      </details>
+    </div>
+  </section>
+</template>

--- a/components/features/team/TeamRankSection.vue
+++ b/components/features/team/TeamRankSection.vue
@@ -39,6 +39,7 @@ const profileHref = (slug?: string) => slug ? `/${locale.value}/team/${slug}` : 
         :role="p.role || rankLabel"
         :slogan="p.slogan"
         :apply-url="p.applyUrl"
+        :apply-via="p.applyVia"
       />
     </ul>
   </section>

--- a/composables/useTeamFaqContent.ts
+++ b/composables/useTeamFaqContent.ts
@@ -1,0 +1,24 @@
+import { useContentRepository } from '~/composables/useContentRepository'
+import type { Locale } from '~/utils/content/collections'
+import type { TeamFaqEntry } from '~/types/faq'
+
+/**
+ * Fetches the application/rank-requirement FAQ for the active locale,
+ * ordered by the optional `order` frontmatter field. Kept separate from
+ * the home FAQ so the two surfaces can evolve independently.
+ */
+export function useTeamFaqContent() {
+  const { locale } = useI18n()
+  const repo = useContentRepository()
+  const activeLocale = computed<Locale>(() => (locale?.value || 'en') as Locale)
+
+  const { data: entries } = useAsyncData<TeamFaqEntry[]>(
+    () => `team-faq-${activeLocale.value}`,
+    () => repo.listTeamFaqEntries(activeLocale.value),
+    { watch: [activeLocale] }
+  )
+
+  const items = computed<TeamFaqEntry[]>(() => entries.value || [])
+
+  return { items }
+}

--- a/composables/useTeamProfile.ts
+++ b/composables/useTeamProfile.ts
@@ -3,7 +3,14 @@ import type { Locale } from '~/utils/content/collections'
 import type { TeamDocument, TeamMember } from '~/types/team'
 import { teamAvatarUrl } from '~/utils/teamAvatar'
 
-export function useTeamProfile(slugOverride?: string) {
+/**
+ * Resolves the active team member synchronously on SSR by awaiting the
+ * underlying `useAsyncData` call. This is what lets `usePageSeo` see the
+ * real member name/bio when it runs in the page's setup — without the
+ * await, meta tags ship with the "Team" fallback because the member ref
+ * is still null at SSR render time.
+ */
+export async function useTeamProfile(slugOverride?: string) {
   const route = useRoute()
   const { locale } = useI18n()
   const repo = useContentRepository()
@@ -11,7 +18,7 @@ export function useTeamProfile(slugOverride?: string) {
 
   const slug = computed(() => slugOverride ?? (route.params.slug as string))
 
-  const { data: teamDoc } = useAsyncData<TeamDocument | null>(
+  const { data: teamDoc } = await useAsyncData<TeamDocument | null>(
     () => `team-profile-${activeLocale.value}`,
     () => repo.getTeamDocument(activeLocale.value),
     { watch: [activeLocale] }

--- a/content.config.ts
+++ b/content.config.ts
@@ -86,9 +86,12 @@ const teamSchema = z
             id: z.union([z.string(), z.number()]),
             name: z.string(),
             slug: z.string().optional(),
-            role: z.string().optional(),
+            // Sub-role label(s). A single string keeps existing entries
+            // valid; an array renders one chip per discipline for members
+            // who wear several hats (e.g. development + building).
+            role: z.union([z.string(), z.array(z.string())]).optional(),
             // Coarse group for sectioning/ordering; specific job stays in `role`.
-            rank: z.enum(['admin', 'content', 'moderation']).optional(),
+            rank: z.enum(['admin', 'teamassist', 'content', 'moderation', 'media', 'lite']).optional(),
             slogan: z.string().optional(),
             bio: z.string().optional(),
             since: z.string().optional(),
@@ -98,7 +101,10 @@ const teamSchema = z
             avatarUrl: z.string().url().optional(),
             // Marks an entry as an open position rather than a real member.
             openPosition: z.boolean().optional(),
-            applyUrl: z.string().url().optional()
+            applyUrl: z.string().url().optional(),
+            // Channel for an open position: Discord (regular hiring) or
+            // OpenCollective (the donation-funded Lite rank).
+            applyVia: z.enum(['discord', 'opencollective']).optional()
           })
           .passthrough()
       )
@@ -198,6 +204,11 @@ export default defineContentConfig({
     ...defineLocalizedCollections('faq', (locale) => ({
       type: 'page',
       source: `faq/${locale}/*.md`,
+      schema: faqSchema
+    })),
+    ...defineLocalizedCollections('team_faq', (locale) => ({
+      type: 'page',
+      source: `team-faq/${locale}/*.md`,
       schema: faqSchema
     })),
     authors: defineCollection({

--- a/content/team-faq/de/apply.md
+++ b/content/team-faq/de/apply.md
@@ -1,0 +1,11 @@
+---
+key: apply
+question: Wie kann ich mich auf eine offene Stelle bewerben?
+order: 1
+---
+
+Bewerbungen laufen über unseren Discord. Schreibe dort einer Person aus
+der Administration oder Teamassistenz und nenne kurz, für welche Rolle
+du dich interessierst und was du mitbringst.
+
+Discord beitreten: [1lf.link/discord](https://1lf.link/discord)

--- a/content/team-faq/de/lite.md
+++ b/content/team-faq/de/lite.md
@@ -1,0 +1,14 @@
+---
+key: lite
+question: Was ist der Lite-Rang und wie bekomme ich ihn?
+order: 4
+---
+
+Der Lite-Rang ist kein klassischer Bewerbungsrang. Er wird ausschliesslich
+über freiwillige Spenden auf OpenCollective vergeben und gilt als Dank für
+die finanzielle Unterstützung des Netzwerks.
+
+Die Vergabe ist nicht garantiert: Sie erfolgt auf freiwilliger Basis durch
+die Administration, abhängig vom Spendenstand und der laufenden Finanzierung.
+
+Spenden auf [OpenCollective](https://opencollective.com/onelitefeather).

--- a/content/team-faq/de/no-position.md
+++ b/content/team-faq/de/no-position.md
@@ -1,0 +1,9 @@
+---
+key: no-position
+question: Ich habe Interesse, sehe aber keine passende Stelle. Was kann ich tun?
+order: 5
+---
+
+Schreibe uns trotzdem auf Discord. Wir nehmen Initiativbewerbungen auf,
+wenn die Person zum Team passt und Bedarf entstehen könnte. Eine Garantie
+auf einen Platz gibt es nicht, aber ehrliches Interesse zählt immer.

--- a/content/team-faq/de/process.md
+++ b/content/team-faq/de/process.md
@@ -1,0 +1,13 @@
+---
+key: process
+question: Wie läuft der Bewerbungsprozess ab?
+order: 2
+---
+
+1. Kurzes Vorstellungsgespräch über Discord (Text oder Voice).
+2. Je nach Rolle eine Probeaufgabe (z. B. Bau-Probe, Code-Snippet,
+   Moderations-Szenario).
+3. Probezeit im Team mit klaren Erwartungen und regelmässigem Feedback.
+
+Wir antworten in der Regel innerhalb weniger Tage. Wenn es länger dauert,
+darfst du jederzeit freundlich nachhaken.

--- a/content/team-faq/de/requirements.md
+++ b/content/team-faq/de/requirements.md
@@ -1,0 +1,25 @@
+---
+key: requirements
+question: Welche Anforderungen gibt es für die einzelnen Ränge?
+order: 3
+---
+
+**Administration:** Mehrjährige Erfahrung im Betrieb von Minecraft-Netzwerken,
+Verantwortung für Infrastruktur, Team und Strategie.
+
+**Teamassistenz:** Unterstützt die Administration im Tagesgeschäft. Gute
+Kommunikation, Zuverlässigkeit und ein Überblick über alle Teilbereiche.
+
+**Content (Entwicklung, Bau-Team, Konzepte):** Konkretes Portfolio im
+gewünschten Bereich. Entwicklung: Java/Kotlin mit Paper/Velocity oder
+Minestom, dazu ein Grundverständnis von Kubernetes. Bau-Team:
+Referenzbauten. Konzepte: ausgearbeitete Spielmodi oder Eventideen.
+
+**Moderation:** Mindestalter 16, ruhiges Auftreten, regelmässige Online-Zeit
+und Bereitschaft, Regeln fair und konsistent durchzusetzen.
+
+**Media:** Gedacht für YouTuber, Streamer und Content Creator rund um
+das Netzwerk. Eigene Reichweite oder erste Inhalte (Videos, Streams,
+Highlights) und Lust, regelmässig zu veröffentlichen.
+
+**Lite:** Kein Bewerbungsrang. Siehe Frage zum Lite-Rang weiter unten.

--- a/content/team-faq/en/apply.md
+++ b/content/team-faq/en/apply.md
@@ -1,0 +1,11 @@
+---
+key: apply
+question: How do I apply for an open position?
+order: 1
+---
+
+Applications run through our Discord. Reach out to someone from
+Administration or Team Assistance, briefly tell us which role you are
+interested in and what you bring to the table.
+
+Join Discord: [1lf.link/discord](https://1lf.link/discord)

--- a/content/team-faq/en/lite.md
+++ b/content/team-faq/en/lite.md
@@ -1,0 +1,15 @@
+---
+key: lite
+question: What is the Lite rank and how do I get it?
+order: 4
+---
+
+The Lite rank is not a classic application rank. It is granted only
+through voluntary donations on OpenCollective and serves as a thank-you
+for financially supporting the network.
+
+Awarding it is not guaranteed: it happens at the discretion of the
+Administration, depending on the current donation level and ongoing
+funding.
+
+Donate on [OpenCollective](https://opencollective.com/onelitefeather).

--- a/content/team-faq/en/no-position.md
+++ b/content/team-faq/en/no-position.md
@@ -1,0 +1,9 @@
+---
+key: no-position
+question: I am interested but no role fits. What can I do?
+order: 5
+---
+
+Reach out on Discord anyway. We accept speculative applications when the
+person fits the team and a need could come up. There is no guarantee of
+a seat, but honest interest is always welcome.

--- a/content/team-faq/en/process.md
+++ b/content/team-faq/en/process.md
@@ -1,0 +1,14 @@
+---
+key: process
+question: What does the application process look like?
+order: 2
+---
+
+1. A short introduction chat on Discord (text or voice).
+2. A role-specific trial task where it fits (build sample, code snippet,
+   moderation scenario).
+3. A probation period inside the team with clear expectations and
+   regular feedback.
+
+We usually reply within a few days. If it takes longer, feel free to
+politely follow up.

--- a/content/team-faq/en/requirements.md
+++ b/content/team-faq/en/requirements.md
@@ -1,0 +1,25 @@
+---
+key: requirements
+question: What are the requirements for each rank?
+order: 3
+---
+
+**Administration:** Multiple years of experience running Minecraft
+networks, responsibility for infrastructure, team and strategy.
+
+**Team Assistance:** Supports Administration in day-to-day operations.
+Strong communication, reliability and an overview across all areas.
+
+**Content (Development, Building Team, Concepts):** A concrete portfolio
+in your area. Development: Java/Kotlin with Paper/Velocity or Minestom,
+plus a working understanding of Kubernetes. Building: reference builds.
+Concepts: fleshed-out game modes or event ideas.
+
+**Moderation:** Minimum age 16, calm presence, regular online time and
+the willingness to enforce rules fairly and consistently.
+
+**Media:** Intended for YouTubers, streamers and content creators
+around the network. Existing reach or first content (videos, streams,
+highlights) and the motivation to publish regularly.
+
+**Lite:** Not an application rank. See the Lite question below.

--- a/content/team/de/home.json
+++ b/content/team/de/home.json
@@ -7,6 +7,7 @@
       "slug": "themeinerlp",
       "rank": "admin",
       "slogan": "Just Sudo IT.",
+      "bio": "Kümmert sich um Kubernetes, Proxmox, Infrastruktur, Entwicklung, DevOps, Strategie und Technical Interviews.",
       "href": "/de/team/themeinerlp"
     },
     {
@@ -15,12 +16,30 @@
       "slug": "selenretterin",
       "rank": "admin",
       "slogan": "aka OneLiteFeather",
+      "bio": "Verantwortlich für Strategie, Marketing und Social Media.",
       "href": "/de/team/selenretterin"
+    },
+    {
+      "id": "theevilreaper",
+      "name": "theEvilReaper",
+      "slug": "theevilreaper",
+      "rank": "admin",
+      "bio": "Macht GitHub, Minestom-Entwicklung, alles rund um Minigames, exotische Entwicklung und Technical Interviews.",
+      "href": "/de/team/theevilreaper"
+    },
+    {
+      "id": "alex-m",
+      "name": "Alex M.",
+      "slug": "alex-m",
+      "role": "Teamassistenz",
+      "rank": "teamassist",
+      "href": "/de/team/alex-m"
     },
     {
       "id": "joltra",
       "name": "Joltra",
       "slug": "joltra",
+      "role": "Entwicklung",
       "rank": "content",
       "href": "/de/team/joltra"
     },
@@ -28,65 +47,50 @@
       "id": "theshadowsdust",
       "name": "theShadowsDust",
       "slug": "theshadowsdust",
+      "role": "Entwicklung",
       "rank": "content",
       "slogan": "I feel like I'm upside down.",
       "href": "/de/team/theshadowsdust"
     },
     {
-      "id": "alex-m",
-      "name": "Alex M.",
-      "slug": "alex-m",
-      "rank": "content",
-      "href": "/de/team/alex-m"
-    },
-    {
-      "id": "bavariankingdom",
-      "name": "BavarianKingdom",
-      "slug": "bavariankingdom",
-      "rank": "content",
-      "href": "/de/team/bavariankingdom"
-    },
-    {
       "id": "mcmdev",
       "name": "mcmdev",
       "slug": "mcmdev",
+      "role": "Entwicklung",
       "rank": "content",
       "href": "/de/team/mcmdev"
-    },
-    {
-      "id": "pega",
-      "name": "Pega",
-      "slug": "pega",
-      "rank": "content",
-      "href": "/de/team/pega"
     },
     {
       "id": "random",
       "name": "Random",
       "slug": "random",
+      "role": "Entwicklung",
       "rank": "content",
       "href": "/de/team/random"
+    },
+    {
+      "id": "pega",
+      "name": "Pega",
+      "slug": "pega",
+      "role": "Bau-Team",
+      "rank": "content",
+      "href": "/de/team/pega"
+    },
+    {
+      "id": "weltspielt",
+      "name": "weltspielt",
+      "slug": "weltspielt",
+      "role": "Content & Konzepte",
+      "rank": "content",
+      "href": "/de/team/weltspielt"
     },
     {
       "id": "saynax-jonas",
       "name": "Saynax | Jonas",
       "slug": "saynax-jonas",
       "rank": "content",
+      "bio": "Kümmert sich um Infra, DevOps und Security.",
       "href": "/de/team/saynax-jonas"
-    },
-    {
-      "id": "theevilreaper",
-      "name": "theEvilReaper",
-      "slug": "theevilreaper",
-      "rank": "admin",
-      "href": "/de/team/theevilreaper"
-    },
-    {
-      "id": "weltspielt",
-      "name": "weltspielt",
-      "slug": "weltspielt",
-      "rank": "content",
-      "href": "/de/team/weltspielt"
     },
     {
       "id": "open-content",
@@ -96,6 +100,15 @@
       "slogan": "Erstelle Content, baue Welten oder entwickle mit uns.",
       "openPosition": true,
       "applyUrl": "https://1lf.link/discord"
+    },
+    {
+      "id": "bavariankingdom",
+      "name": "BavarianKingdom",
+      "slug": "bavariankingdom",
+      "role": "Moderation",
+      "rank": "moderation",
+      "mcName": "morelia0815",
+      "href": "/de/team/bavariankingdom"
     },
     {
       "id": "b3nny",
@@ -113,6 +126,25 @@
       "slogan": "Sorge für eine faire und freundliche Community.",
       "openPosition": true,
       "applyUrl": "https://1lf.link/discord"
+    },
+    {
+      "id": "open-media",
+      "name": "Dein Platz?",
+      "role": "Media",
+      "rank": "media",
+      "slogan": "Für YouTuber, Streamer und alle, die Content rund um den Server machen.",
+      "openPosition": true,
+      "applyUrl": "https://1lf.link/discord"
+    },
+    {
+      "id": "open-lite",
+      "name": "Lite-Rang",
+      "role": "Lite",
+      "rank": "lite",
+      "slogan": "Den Lite-Rang gibt es nur über freiwillige Spenden via OpenCollective. Die Vergabe ist nicht garantiert.",
+      "openPosition": true,
+      "applyUrl": "https://opencollective.com/onelitefeather",
+      "applyVia": "opencollective"
     }
   ]
 }

--- a/content/team/en/home.json
+++ b/content/team/en/home.json
@@ -7,6 +7,7 @@
       "slug": "themeinerlp",
       "rank": "admin",
       "slogan": "Just Sudo IT.",
+      "bio": "Handles Kubernetes, Proxmox, infrastructure, development, DevOps, strategy and technical interviews.",
       "href": "/en/team/themeinerlp"
     },
     {
@@ -15,12 +16,30 @@
       "slug": "selenretterin",
       "rank": "admin",
       "slogan": "aka OneLiteFeather",
+      "bio": "Owns strategy, marketing and social media.",
       "href": "/en/team/selenretterin"
+    },
+    {
+      "id": "theevilreaper",
+      "name": "theEvilReaper",
+      "slug": "theevilreaper",
+      "rank": "admin",
+      "bio": "Works on GitHub, Minestom development, everything around minigames, exotic development and technical interviews.",
+      "href": "/en/team/theevilreaper"
+    },
+    {
+      "id": "alex-m",
+      "name": "Alex M.",
+      "slug": "alex-m",
+      "role": "Team Assistance",
+      "rank": "teamassist",
+      "href": "/en/team/alex-m"
     },
     {
       "id": "joltra",
       "name": "Joltra",
       "slug": "joltra",
+      "role": "Development",
       "rank": "content",
       "href": "/en/team/joltra"
     },
@@ -28,65 +47,50 @@
       "id": "theshadowsdust",
       "name": "theShadowsDust",
       "slug": "theshadowsdust",
+      "role": "Development",
       "rank": "content",
       "slogan": "I feel like I'm upside down.",
       "href": "/en/team/theshadowsdust"
     },
     {
-      "id": "alex-m",
-      "name": "Alex M.",
-      "slug": "alex-m",
-      "rank": "content",
-      "href": "/en/team/alex-m"
-    },
-    {
-      "id": "bavariankingdom",
-      "name": "BavarianKingdom",
-      "slug": "bavariankingdom",
-      "rank": "content",
-      "href": "/en/team/bavariankingdom"
-    },
-    {
       "id": "mcmdev",
       "name": "mcmdev",
       "slug": "mcmdev",
+      "role": "Development",
       "rank": "content",
       "href": "/en/team/mcmdev"
-    },
-    {
-      "id": "pega",
-      "name": "Pega",
-      "slug": "pega",
-      "rank": "content",
-      "href": "/en/team/pega"
     },
     {
       "id": "random",
       "name": "Random",
       "slug": "random",
+      "role": "Development",
       "rank": "content",
       "href": "/en/team/random"
+    },
+    {
+      "id": "pega",
+      "name": "Pega",
+      "slug": "pega",
+      "role": "Building Team",
+      "rank": "content",
+      "href": "/en/team/pega"
+    },
+    {
+      "id": "weltspielt",
+      "name": "weltspielt",
+      "slug": "weltspielt",
+      "role": "Content & Concepts",
+      "rank": "content",
+      "href": "/en/team/weltspielt"
     },
     {
       "id": "saynax-jonas",
       "name": "Saynax | Jonas",
       "slug": "saynax-jonas",
       "rank": "content",
+      "bio": "Handles infra, DevOps and security.",
       "href": "/en/team/saynax-jonas"
-    },
-    {
-      "id": "theevilreaper",
-      "name": "theEvilReaper",
-      "slug": "theevilreaper",
-      "rank": "admin",
-      "href": "/en/team/theevilreaper"
-    },
-    {
-      "id": "weltspielt",
-      "name": "weltspielt",
-      "slug": "weltspielt",
-      "rank": "content",
-      "href": "/en/team/weltspielt"
     },
     {
       "id": "open-content",
@@ -96,6 +100,15 @@
       "slogan": "Create content, build worlds or write code with us.",
       "openPosition": true,
       "applyUrl": "https://1lf.link/discord"
+    },
+    {
+      "id": "bavariankingdom",
+      "name": "BavarianKingdom",
+      "slug": "bavariankingdom",
+      "role": "Moderation",
+      "rank": "moderation",
+      "mcName": "morelia0815",
+      "href": "/en/team/bavariankingdom"
     },
     {
       "id": "b3nny",
@@ -113,6 +126,25 @@
       "slogan": "Keep the community fair and friendly.",
       "openPosition": true,
       "applyUrl": "https://1lf.link/discord"
+    },
+    {
+      "id": "open-media",
+      "name": "Your seat?",
+      "role": "Media",
+      "rank": "media",
+      "slogan": "For YouTubers, streamers and anyone creating content around the server.",
+      "openPosition": true,
+      "applyUrl": "https://1lf.link/discord"
+    },
+    {
+      "id": "open-lite",
+      "name": "Lite Rank",
+      "role": "Lite",
+      "rank": "lite",
+      "slogan": "The Lite rank is granted only through voluntary donations via OpenCollective. Awarding it is not guaranteed.",
+      "openPosition": true,
+      "applyUrl": "https://opencollective.com/onelitefeather",
+      "applyVia": "opencollective"
     }
   ]
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -67,7 +67,7 @@
   "team": {
     "title": "Team",
     "subtitle": "Lerne die Menschen hinter OneLiteFeather kennen.",
-    "profile_title_fallback": "Team — OneLiteFeather",
+    "profile_title_fallback": "Team",
     "profile_description_fallback": "Teammitglied-Profil bei OneLiteFeather.",
     "search_label": "Team durchsuchen",
     "search_placeholder": "Name suchen…",
@@ -84,8 +84,8 @@
     "member_since": "Teil des Teams seit {year}",
     "profile_link_aria": "{platform}-Profil von {name}",
     "index": {
-      "title": "Unser Team — OneLiteFeather",
-      "subtitle": "Die Menschen hinter dem Netzwerk – und die freien Plätze, die auf dich warten.",
+      "title": "Unser Team",
+      "subtitle": "Die Menschen hinter dem Netzwerk und die freien Plätze, die auf dich warten.",
       "description": "Lerne das OneLiteFeather-Team nach Rollen geordnet kennen und entdecke die offenen Stellen, auf die du dich bewerben kannst."
     },
     "ranks": {
@@ -93,13 +93,19 @@
       "teamassist": "Teamassistenz",
       "content": "Content",
       "moderation": "Moderation",
-      "media": "Social Media",
+      "media": "Media",
       "lite": "Lite"
     },
     "open_position": {
       "badge": "Offene Stelle",
       "apply": "Über Discord bewerben",
-      "apply_aria": "Für {role} über Discord bewerben"
+      "apply_aria": "Für {role} über Discord bewerben",
+      "apply_opencollective": "Über OpenCollective unterstützen",
+      "apply_aria_opencollective": "{role} über OpenCollective unterstützen"
+    },
+    "faq": {
+      "section_title": "Bewerbungen und Ränge",
+      "section_subtitle": "Antworten zu Ablauf, Anforderungen und dem Lite-Rang."
     }
   },
   "timeline": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -67,7 +67,7 @@
   "team": {
     "title": "Team",
     "subtitle": "Meet the people behind OneLiteFeather.",
-    "profile_title_fallback": "Team — OneLiteFeather",
+    "profile_title_fallback": "Team",
     "profile_description_fallback": "Team member profile on OneLiteFeather.",
     "search_label": "Search team",
     "search_placeholder": "Search name…",
@@ -84,8 +84,8 @@
     "member_since": "Part of the team since {year}",
     "profile_link_aria": "{platform} profile of {name}",
     "index": {
-      "title": "Our Team — OneLiteFeather",
-      "subtitle": "The people behind the network — and the open seats waiting for you.",
+      "title": "Our Team",
+      "subtitle": "The people behind the network, and the open seats waiting for you.",
       "description": "Meet the OneLiteFeather team, organised by role, and discover the open positions you can apply for."
     },
     "ranks": {
@@ -93,13 +93,19 @@
       "teamassist": "Team Assistance",
       "content": "Content",
       "moderation": "Moderation",
-      "media": "Social Media",
+      "media": "Media",
       "lite": "Lite"
     },
     "open_position": {
       "badge": "Open position",
       "apply": "Apply via Discord",
-      "apply_aria": "Apply for {role} via Discord"
+      "apply_aria": "Apply for {role} via Discord",
+      "apply_opencollective": "Support via OpenCollective",
+      "apply_aria_opencollective": "Support {role} via OpenCollective"
+    },
+    "faq": {
+      "section_title": "Applications and ranks",
+      "section_subtitle": "Answers on the process, requirements, and the Lite rank."
     }
   },
   "timeline": {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -99,6 +99,12 @@ export default defineNuxtConfig({
             {label: 'Last Modified', select: 'sitemap:lastmod', width: '25%'},
             {label: 'Language', select: 'sitemap:hreflang', width: '25%'}
         ],
+        // Team profiles live in a data-type content collection so they're
+        // not auto-discovered. We materialise the per-member URLs through
+        // a Nitro endpoint that reads the same JSON the page uses.
+        sources: [
+            '/api/__sitemap__/team'
+        ],
         defaults: {
             changefreq: 'weekly',
             priority: 0.8

--- a/pages/team/[slug].vue
+++ b/pages/team/[slug].vue
@@ -1,18 +1,50 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { faGithub, faDiscord, faLinkedinIn } from '@fortawesome/free-brands-svg-icons'
-import { faGlobe, faLink } from '@fortawesome/free-solid-svg-icons'
+import {
+  faGithub,
+  faDiscord,
+  faLinkedinIn,
+  faXTwitter,
+  faTwitter,
+  faMastodon,
+  faBluesky,
+  faYoutube,
+  faTwitch,
+  faInstagram,
+  faTiktok
+} from '@fortawesome/free-brands-svg-icons'
+import { faGlobe, faLink, faEnvelope } from '@fortawesome/free-solid-svg-icons'
+import UiChip from '~/components/base/Chip.vue'
+import { toRoleList, toRoleString } from '~/utils/teamRoles'
 
 const { t, locale } = useI18n()
 const site = useSiteConfig()
 
-const { member, avatarSrc } = useTeamProfile()
+const { member, avatarSrc } = await useTeamProfile()
 
+const memberRoles = computed(() => toRoleList(member.value?.role))
+const memberRoleText = computed(() => toRoleString(member.value?.role))
+
+// Free-form `links` keys map to recognised brand icons; anything unknown
+// falls back to a generic chain glyph. Keys are matched case-insensitively
+// so the team JSON can use "GitHub"/"github" interchangeably.
 const linkIcons: Record<string, typeof faLink> = {
   github: faGithub,
   discord: faDiscord,
   linkedin: faLinkedinIn,
-  website: faGlobe
+  twitter: faTwitter,
+  x: faXTwitter,
+  mastodon: faMastodon,
+  bluesky: faBluesky,
+  youtube: faYoutube,
+  twitch: faTwitch,
+  instagram: faInstagram,
+  tiktok: faTiktok,
+  website: faGlobe,
+  homepage: faGlobe,
+  blog: faGlobe,
+  email: faEnvelope,
+  mail: faEnvelope
 }
 
 const profileLinks = computed(() => {
@@ -28,11 +60,18 @@ const profileLinks = computed(() => {
 
 const rankLabel = computed(() => member.value?.rank ? t(`team.ranks.${member.value.rank}`) : null)
 
+// Bio first (full description), then slogan, then role list as fallback.
+// `image` uses the Cloudflare-rendered avatar so social previews show the
+// player's head instead of the synthetic OG fallback.
 usePageSeo({
-  title: member.value ? `${member.value.name} — OneLiteFeather` : t('team.profile_title_fallback'),
-  description: member.value?.slogan || member.value?.role || t('team.profile_description_fallback'),
-  image: member.value?.avatar || undefined,
+  title: member.value ? member.value.name : t('team.profile_title_fallback'),
+  description: member.value?.bio
+    || member.value?.slogan
+    || memberRoleText.value
+    || t('team.profile_description_fallback'),
+  image: avatarSrc.value && avatarSrc.value !== '/favicon.svg' ? avatarSrc.value : undefined,
   imageAlt: member.value ? t('team.avatar_alt', { name: member.value.name }) : undefined,
+  ogType: 'profile',
   schemaType: 'ProfilePage',
 })
 
@@ -60,12 +99,37 @@ useSchemaOrg(() => {
       name: member.value.name,
       url: profileUrl,
       image: avatar,
-      jobTitle: member.value.role || undefined,
-      description: member.value.slogan || member.value.role || undefined,
+      jobTitle: memberRoleText.value || undefined,
+      description: member.value.bio || member.value.slogan || memberRoleText.value || undefined,
+      sameAs: Object.values((member.value.links || {}) as Record<string, string>).filter(Boolean),
       worksFor: { '@id': organizationId(site.url) }
     }
   ]
 })
+
+// Custom OG image that puts the Minecraft head, the actual member name
+// and their bio into the social preview, instead of the generic NuxtSeo
+// banner that `usePageSeo` registers by default. Called after
+// `usePageSeo` so the second `defineOgImage` call wins.
+if (member.value) {
+  const ogDescription = member.value.bio
+    || member.value.slogan
+    || memberRoleText.value
+    || ''
+  // Use the 3D-rendered head from mc-heads.net for the OG image — it
+  // reads better at OG card sizes than the flat avatar. Satori fetches
+  // this absolute URL at render time.
+  const mcId = member.value.mcName || member.value.slug || 'Steve'
+  const ogAvatar = member.value.avatarUrl
+    || `https://mc-heads.net/head/${encodeURIComponent(mcId)}/256`
+  defineOgImage('TeamMember', {
+    name: member.value.name,
+    description: ogDescription,
+    roleText: memberRoleText.value || undefined,
+    rankLabel: rankLabel.value || undefined,
+    avatarUrl: ogAvatar
+  })
+}
 </script>
 
 <template>
@@ -98,7 +162,15 @@ useSchemaOrg(() => {
               class="rounded-full bg-brand-100 dark:bg-brand-900/40 px-2.5 py-0.5 text-xs font-semibold text-brand-700 dark:text-brand-300"
             >{{ rankLabel }}</span>
           </div>
-          <p class="text-sm md:text-base text-gray-600 dark:text-gray-400">{{ member.role }}</p>
+          <div v-if="memberRoles.length" class="mt-2 flex flex-wrap gap-2">
+            <UiChip
+              v-for="chip in memberRoles"
+              :key="chip"
+              :label="chip"
+              variant="outlined"
+              as="span"
+            />
+          </div>
           <p v-if="member.slogan" class="mt-2 text-gray-700 dark:text-gray-300">"{{ member.slogan }}"</p>
           <p v-if="member.since" class="mt-1 text-xs text-gray-500 dark:text-gray-500">
             {{ t('team.member_since', { year: member.since }) }}

--- a/pages/team/index.vue
+++ b/pages/team/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { definePageMeta } from '#imports'
 import TeamRankSection from '~/components/features/team/TeamRankSection.vue'
+import TeamFaqSection from '~/components/features/team/TeamFaqSection.vue'
 
 const { t, locale } = useI18n()
 const site = useSiteConfig()
@@ -73,5 +74,7 @@ useSchemaOrg(() => {
     >
       {{ t('team.no_results') }}
     </p>
+
+    <TeamFaqSection />
   </main>
 </template>

--- a/server/api/__sitemap__/team.ts
+++ b/server/api/__sitemap__/team.ts
@@ -1,0 +1,30 @@
+import { queryCollection } from '@nuxt/content/server'
+import type { TeamDocument, TeamMember } from '~/types/team'
+
+/**
+ * Sitemap source for individual team profile pages.
+ *
+ * The team JSON is a `data`-type Nuxt Content collection (a single
+ * document per locale), so the per-member URLs don't fall out of
+ * `asSitemapCollection` the way blog posts do. We materialise them
+ * here, one entry per locale × member, so both /de/team/<slug> and
+ * /en/team/<slug> end up in the per-locale sitemaps.
+ */
+type LocaleKey = 'de' | 'en'
+
+const LOCALES: ReadonlyArray<LocaleKey> = ['de', 'en']
+
+export default defineEventHandler(async (event) => {
+  const out: { loc: string }[] = []
+  for (const locale of LOCALES) {
+    const key = `team_${locale}` as 'team_de' | 'team_en'
+    const docs = (await queryCollection(event, key).all()) as TeamDocument[]
+    const doc = docs[0]
+    const members = (doc?.members || []) as TeamMember[]
+    for (const m of members) {
+      if (!m.slug || m.openPosition) continue
+      out.push({ loc: `/${locale}/team/${m.slug}` })
+    }
+  }
+  return out
+})

--- a/types/faq.ts
+++ b/types/faq.ts
@@ -15,3 +15,10 @@ export interface FaqEntry extends PageCollectionItemBase {
   question: string
   order?: number
 }
+
+/**
+ * Team-page FAQ entries share the structural contract of {@link FaqEntry}
+ * but live in their own collection so the home FAQ stays focused on the
+ * server-product questions.
+ */
+export type TeamFaqEntry = FaqEntry

--- a/utils/content/nuxtContentAdapter.ts
+++ b/utils/content/nuxtContentAdapter.ts
@@ -2,7 +2,7 @@ import { queryCollection } from '#imports'
 import type { Locale } from './collections'
 import type { ContentRepository } from './repository'
 import type { BlogArticle, BlogAuthorProfile } from '~/types/blog'
-import type { FaqEntry } from '~/types/faq'
+import type { FaqEntry, TeamFaqEntry } from '~/types/faq'
 import type { TeamDocument } from '~/types/team'
 import type {
   ServerConceptDocument,
@@ -18,6 +18,7 @@ import type { SponsorsDocument } from '~/types/sponsoring'
 // stay confined to this file.
 const blogKey = (locale: Locale) => `blog_${locale}` as 'blog_de' | 'blog_en'
 const faqKey = (locale: Locale) => `faq_${locale}` as 'faq_de' | 'faq_en'
+const teamFaqKey = (locale: Locale) => `team_faq_${locale}` as 'team_faq_de' | 'team_faq_en'
 const teamKey = (locale: Locale) => `team_${locale}` as 'team_de' | 'team_en'
 const sponsorsKey = (locale: Locale) => `sponsors_${locale}` as 'sponsors_de' | 'sponsors_en'
 const serverConceptKey = (locale: Locale) => `server_concept_${locale}` as 'server_concept_de' | 'server_concept_en'
@@ -65,6 +66,12 @@ export function createNuxtContentAdapter(): ContentRepository {
     async getTeamDocument(locale) {
       const docs = await queryCollection(teamKey(locale)).all()
       return (docs[0] ?? null) as TeamDocument | null
+    },
+
+    listTeamFaqEntries(locale) {
+      return queryCollection(teamFaqKey(locale))
+        .order('order', 'ASC')
+        .all() as Promise<TeamFaqEntry[]>
     },
 
     async getServerConcept(locale) {

--- a/utils/content/repository.ts
+++ b/utils/content/repository.ts
@@ -1,6 +1,6 @@
 import type { Locale } from './collections'
 import type { BlogArticle, BlogAuthorProfile } from '~/types/blog'
-import type { FaqEntry } from '~/types/faq'
+import type { FaqEntry, TeamFaqEntry } from '~/types/faq'
 import type { TeamDocument } from '~/types/team'
 import type {
   ServerConceptDocument,
@@ -44,6 +44,8 @@ export interface ContentRepository {
   // --- Team -----------------------------------------------------------------
   /** The single team document for a locale, or null. */
   getTeamDocument(locale: Locale): Promise<TeamDocument | null>
+  /** Team-page FAQ entries (applications, rank requirements), ordered ascending. */
+  listTeamFaqEntries(locale: Locale): Promise<TeamFaqEntry[]>
 
   // --- Home -----------------------------------------------------------------
   getServerConcept(locale: Locale): Promise<ServerConceptDocument | null>

--- a/utils/teamRoles.ts
+++ b/utils/teamRoles.ts
@@ -1,0 +1,32 @@
+/**
+ * The team `role` field accepts either a single label or an array of
+ * labels so a member can carry multiple sub-roles (e.g. "Entwicklung"
+ * and "Bau-Team"). These helpers funnel both shapes into the form each
+ * call site needs without leaking the union into the templates.
+ */
+
+type RoleField = string | string[] | undefined | null
+
+/** Trim, drop empties, and de-duplicate the role list. Always an array. */
+export function toRoleList(role: RoleField): string[] {
+  if (!role) return []
+  const raw = Array.isArray(role) ? role : [role]
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const entry of raw) {
+    const value = String(entry).trim()
+    if (!value || seen.has(value)) continue
+    seen.add(value)
+    out.push(value)
+  }
+  return out
+}
+
+/**
+ * Plain-text form for contexts that can't render multiple chips, e.g.
+ * schema.org `jobTitle`, SEO descriptions, and aria labels. Joins
+ * entries with " · " to mirror the existing role-separator convention.
+ */
+export function toRoleString(role: RoleField): string {
+  return toRoleList(role).join(' · ')
+}


### PR DESCRIPTION
Roster
- Tag developers (joltra, theShadowsDust, mcmdev, Random) as Entwicklung, Pega as Bau-Team, weltspielt as Content & Konzepte; promote Alex M. to Teamassistenz and move BavarianKingdom into Moderation with their real MC name (morelia0815) so the head render resolves correctly
- Add permanent open positions for Social Media (Media rank) and the donation-funded Lite rank; the Lite card links to OpenCollective and uses a heart icon via a new `applyVia` field on the team schema
- Extend the rank enum to cover teamassist/media/lite

FAQ
- New `team_faq` content collection (DE/EN markdown) with five entries covering how to apply, the process, per-rank requirements, the Lite rank, and speculative applications
- Repository contract gains `listTeamFaqEntries`; `useTeamFaqContent` composable + `TeamFaqSection` accordion mounted below the roster, with its own FAQPage schema.org block

UI
- Sub-roles render as outlined chips under each team member name (TeamMemberCard), reusing the shared Chip component

Copy
- Strip em-dashes from team titles/subtitles and the profile page; lean on the existing "| OneLiteFeather.net" title template instead

## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #{issue number}

## Description
<!-- Please describe what this pull request does. -->

### Submitter Checklist
- [ ] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [ ] I read and followed the [contribution guidelines](https://github.com/OneLiteFeatherNET/.github/blob/main/CONTRIBUTING.md).

