### PR TITLE
home: promote cluster-resilience post in the homepage carousel

### DIFF
--- a/content/carousel/de/home.json
+++ b/content/carousel/de/home.json
@@ -15,6 +15,16 @@
     },
     {
       "type": "blog",
+      "title": "Wenn ein Server ausfällt – und niemand merkt es",
+      "href": "/de/blog/wenn-ein-server-ausfaellt-cluster-resilienz",
+      "excerpt": "Wie wir unser Cluster Stück für Stück ausfallsicher gemacht haben – in Alltagsbildern erzählt.",
+      "image": "/images/blog/cluster-topology-social.png",
+      "author": "Phillipp Glanz",
+      "date": "2026-06-13",
+      "tag": "Blog"
+    },
+    {
+      "type": "blog",
       "title": "Otis: Zentrale Spielerstammdaten für Minecraft",
       "href": "/de/blog/otis-zentrale-spielerstammdaten-minecraft",
       "excerpt": "UUID v4/v7, Name und Sprache als verlässliche Basis für Services.",

--- a/content/carousel/en/home.json
+++ b/content/carousel/en/home.json
@@ -15,6 +15,16 @@
     },
     {
       "type": "blog",
+      "title": "When a Server Fails – and Nobody Notices",
+      "href": "/en/blog/when-a-server-fails-cluster-resilience",
+      "excerpt": "How we made our cluster resilient step by step – told in everyday images.",
+      "image": "/images/blog/cluster-topology-social.png",
+      "author": "Phillipp Glanz",
+      "date": "2026-06-13",
+      "tag": "Blog"
+    },
+    {
+      "type": "blog",
       "title": "DevBlog #1",
       "href": "/en/blog/dev-blog-1-what-we-using",
       "excerpt": "Overview of the technologies we use and why they benefit us.",


### PR DESCRIPTION
Adds a featured blog slide to the homepage carousel (DE + EN) for the Light edition **"When a Server Fails / Wenn ein Server ausfällt"**, placed as the newest blog entry.

- `content/carousel/de/home.json` + `content/carousel/en/home.json`
- Image via R2: `/images/blog/cluster-topology-social.png`
- Links to `/{de,en}/blog/...-cluster-resilien{z,ce}`

Chose the Light edition (non-technical) as the homepage-facing promo; the Deep Dive stays in the blog index.

🤖 Generated with [Claude Code](https://claude.ai/referral/m5Ak2Sa7aQ)