### PR TITLE
fix(privacy): remove the Google Ads tag and stop PostHog capturing without consent

### DIFF
--- a/.claude/skills/nuxt-seo/SKILL.md
+++ b/.claude/skills/nuxt-seo/SKILL.md
@@ -129,8 +129,13 @@ must precede `@nuxt/content`):
 ['@vueuse/nuxt', 'nuxt-link-checker', 'nuxt-site-config', '@nuxt/eslint',
  '@nuxtjs/i18n', '@nuxtjs/seo', '@nuxtjs/robots', '@nuxtjs/sitemap',
  '@nuxt/image', 'nuxt-og-image', '@nuxt/content', 'nuxt-posthog',
- 'nuxt-gtag', 'nuxt-vitalizer']
+ 'nuxt-vitalizer']
 ```
+
+`nuxt-gtag` was removed: it loaded a Google Ads tag with no consent layer in
+front of it. Do not add it — or any other analytics module — back without one.
+PostHog stays, but runs with `opt_out_capturing_by_default: true` until a
+consent mechanism exists.
 
 ## Verify
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -77,7 +77,6 @@ export default defineNuxtConfig({
       'nuxt-og-image',
       '@nuxt/content',
       'nuxt-posthog',
-      'nuxt-gtag',
       'nuxt-vitalizer'
     ],
     robots: {
@@ -173,7 +172,13 @@ export default defineNuxtConfig({
         host: 'https://eu.i.posthog.com',
         proxy: true,
         clientOptions: {
-            person_profiles: 'always'
+            // No consent layer exists yet, so capture must not start on its own.
+            // `identified_only` stops a person profile (and its cookie) from being
+            // created for every anonymous visitor; `opt_out_capturing_by_default`
+            // holds all capture until something explicitly opts in. Remove both
+            // only together with a real consent mechanism.
+            person_profiles: 'identified_only',
+            opt_out_capturing_by_default: true
         }
     },
     content: {
@@ -284,18 +289,13 @@ export default defineNuxtConfig({
             host: 'https://eu.i.posthog.com',
             proxy: true,
             clientOptions: {
-                person_profiles: 'always'
+                // Mirrors the base config above; see the comment there.
+                person_profiles: 'identified_only',
+                opt_out_capturing_by_default: true
             }
         },
         site: {
             url: 'https://onelitefeather.net',
-        },
-        gtag: {
-            id: 'AW-16761048144',
-            config: {
-                anonymize_ip: true,
-                send_page_view: true
-            }
         },
         image: {
             format: ['avif', 'webp'],

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "eslint-plugin-vuejs-accessibility": "^2.5.0",
     "nitro": "3.0.260429-beta",
     "nuxt": "^4.2.1",
-    "nuxt-gtag": "4.1.0",
     "nuxt-og-image": "6.5.3",
     "nuxt-posthog": "1.6.3",
     "nuxt-schema-org": "6.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
       nuxt:
         specifier: ^4.2.1
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.10.1)(cac@7.0.0)(db0@0.3.4(better-sqlite3@12.10.1))(esbuild@0.28.1)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.21)(terser@5.49.0)(typescript@5.9.3)(vite@7.3.6(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
-      nuxt-gtag:
-        specifier: 4.1.0
-        version: 4.1.0(magicast@0.5.3)
       nuxt-og-image:
         specifier: 6.5.3
         version: 6.5.3(57bf1ca252aeb71f83a79231760dd537)
@@ -6360,9 +6357,6 @@ packages:
 
   nuxt-define@1.0.0:
     resolution: {integrity: sha512-CYZ2WjU+KCyCDVzjYUM4eEpMF0rkPmkpiFrybTqqQCRpUbPt2h3snswWIpFPXTi+osRCY6Og0W/XLAQgDL4FfQ==}
-
-  nuxt-gtag@4.1.0:
-    resolution: {integrity: sha512-2TL7RUA8N8NYGbY4UZ9IqKyMZMgO9cCGu6yqadUU8RF+Y81PXI+k+1giIA11XXStaJoGXaXeNsBUIJXn1tUy3A==}
 
   nuxt-link-checker@5.0.10:
     resolution: {integrity: sha512-QHaFlfJFuqhBanW/B4eRHuQOOavV4LgXvtbRqG0jaLp5qd9MPFZFdc+aZ79HGElebQqdVBCToiB2zbjbWr8aZA==}
@@ -14956,15 +14950,6 @@ snapshots:
       - webpack
 
   nuxt-define@1.0.0: {}
-
-  nuxt-gtag@4.1.0(magicast@0.5.3):
-    dependencies:
-      '@nuxt/kit': 4.4.5(magicast@0.5.3)
-      defu: 6.1.7
-      pathe: 2.0.3
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - magicast
 
   nuxt-link-checker@5.0.10(7b5e736523b495a709afbe0f28e20ded):
     dependencies:


### PR DESCRIPTION
Implements **PR-02** from the best-practice audit — its **only critical finding**.

## The problem

The Google Ads tag `AW-16761048144` loaded in production for every visitor with no consent layer in front of it. `nuxt-gtag` defaults to `enabled: true` / `initMode: "auto"` and injects its script unconditionally, and this repository has **no consent mechanism at all**: `plugins/` contains only `fontawesome.js`, and searching the source tree for `consent` returns nothing.

- § 25 Abs. 1 TTDSG — setting the cookie
- Art. 6 Abs. 1 lit. a DSGVO — no legal basis for the processing
- Art. 44 ff. DSGVO — transfer to Google

## Why removed, not disabled

A marketing tag behind `enabled: false` is debt that looks like a fix — it reloads the moment someone flips the flag. Git history is the better place to keep it until a consent layer exists (audit Epic E), where it would have to be rewired for Google Consent Mode v2 anyway.

Confirmed with the maintainer that the Ads conversion data is not in use.

## PostHog stays, but stops capturing on its own

EU-hosted and first-party proxied via `/ingest/ph`, so far less intrusive — but it was still starting unprompted:

| Option | Effect |
|---|---|
| `person_profiles: 'identified_only'` | no person profile (and no `ph-identify` cookie) for anonymous visitors |
| `opt_out_capturing_by_default: true` | all capture held until something explicitly opts in |

Set in the base config **and** in the `$production` duplicate, which restates the whole `posthog` block — that duplication is its own finding (`ARCH-02`, PR-07).

## Verification

Against the built output, with a **positive control** so the absence proves something:

```
posthog                                    -> 2 files under .output/
googletagmanager | google-analytics | AW-  -> 0 files (.output/public + .output/server)
```

The hardening is present in the bundle as `person_profiles:"identified_only"` and `opt_out_capturing_by_default:!0`.

## Note on the quality ratchet

Error counts are unchanged: **404 / 83 / 41**.

An earlier revision of this branch lowered the type-error baseline to 39, claiming the module removal had fixed two. That was wrong — a measurement artefact. `vue-tsc` reports **39** against a `.nuxt` directory left over from `pnpm build`, and **41** against a fresh `nuxt prepare`, which is what CI runs. CI caught it and failed the ratchet, which is precisely what #191 was built to do.

The ratchet should pin that state itself rather than inherit whatever `.nuxt` happens to exist. Tracked as a follow-up so it does not hold up a legal fix.

## Side effect

The `nuxt-seo` skill listed `nuxt-gtag` in its canonical module order and would have become wrong with this change. Updated, with a note not to add analytics back without consent.

## Not in this PR

The privacy policy still describes a consent management platform that does not exist and names none of the services actually loaded. That is **PR-03** — it needs legal review and should land right after this one, since this PR changes what the text has to describe.

Refs: `SEC-01`, `SEC-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s