### PR TITLE
ci: make the quality ratchet measure a reproducible tree

### DIFF
--- a/scripts/quality-gate.mjs
+++ b/scripts/quality-gate.mjs
@@ -13,10 +13,20 @@
  *
  *   node scripts/quality-gate.mjs           # check against the baseline
  *   node scripts/quality-gate.mjs --update  # rewrite the baseline (only lowers)
+ *
+ * The gate deletes and regenerates `.nuxt/` before measuring. Both tools read
+ * generated files from there — ESLint imports `.nuxt/eslint.config.mjs`,
+ * vue-tsc resolves auto-imports and component types through
+ * `.nuxt/tsconfig.json` — so the counts describe whatever state that directory
+ * happens to be in. A working copy that has switched branches, run `pnpm dev`
+ * or built a few times can hold stale generated types and under-report: this
+ * was observed as 39 type errors locally against 41 in CI on the same commit,
+ * which cost a wrong baseline. CI starts from a clean checkout and would never
+ * reproduce it. Regenerating makes both sides measure the same thing.
  */
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -40,6 +50,12 @@ const TSC_ARGS = [
   'tsconfig.json',
 ]
 
+const PREPARE_ARGS = [
+  'exec',
+  'nuxt',
+  'prepare',
+]
+
 const METRICS = [
   ['eslintErrors', 'ESLint errors'],
   ['eslintWarnings', 'ESLint warnings'],
@@ -54,6 +70,15 @@ function run(args) {
     if (error.stdout !== undefined) return error.stdout
     throw error
   }
+}
+
+/**
+ * Rebuild `.nuxt/` from scratch so the counts do not depend on whatever a
+ * previous `pnpm build` or `pnpm dev` happened to leave behind.
+ */
+function prepare() {
+  rmSync(resolve(ROOT, '.nuxt'), { recursive: true, force: true })
+  run(PREPARE_ARGS)
 }
 
 function countEslint() {
@@ -71,6 +96,10 @@ function countTypes() {
 }
 
 const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'))
+
+console.log('\nRegenerating .nuxt/ so the counts are reproducible...')
+prepare()
+
 const actual = { ...countEslint(), ...countTypes() }
 
 let regressed = false


### PR DESCRIPTION
Follow-up to #191 and #193. Fixes a real defect in the ratchet I introduced.

## The problem

The ratchet inherited whatever `.nuxt/` it found. Both tools it runs read generated files from there:

- ESLint imports `.nuxt/eslint.config.mjs`
- `vue-tsc` resolves auto-imports and component types via `.nuxt/tsconfig.json`

So the counts describe **that directory's state**, not the commit's. A working copy that has switched branches, run `pnpm dev` or built a few times can hold stale generated types and under-report.

## How it surfaced

On #193 I measured **39** type errors locally and lowered the baseline accordingly, claiming the `nuxt-gtag` removal had fixed two. CI measured **41** on the same commit and failed the gate.

CI starts from a clean checkout, so it never reproduces the drift. The discrepancy therefore only ever shows up *after* a baseline has been lowered on a phantom win — the worst possible moment, and precisely what happened.

To be clear about the earlier diagnosis: I first attributed this to `pnpm build` versus `nuxt prepare` producing different trees. That was wrong — a build on current `main` also yields 41. The cause is accumulated staleness in a long-lived working copy, not the command that produced it.

## The fix

Delete and regenerate `.nuxt/` before counting.

```
Regenerating .nuxt/ so the counts are reproducible...

  = ESLint errors        404
  = ESLint warnings      83
  = TypeScript errors    41
No regression.
```

## Verification

| Test | Result |
|---|---|
| `pnpm build`, then `pnpm quality` | 41 — no longer influenced by the build |
| Two consecutive `pnpm quality` runs | identical |
| `eslint scripts/quality-gate.mjs` | clean |

**No count changes.** Baseline stays 404 / 83 / 41.

## Cost

Adds one `nuxt prepare` (~10 s) to the quality job. Worth it — a ratchet whose numbers depend on the machine it runs on is worse than no ratchet, because it launders wrong measurements into a committed baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s