### PR TITLE
fix(sitemap): derive blog and POI URLs from the slug instead of the file path

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -5,7 +5,7 @@ import {
   defineLocalizedCollections,
   withI18nMeta
 } from './utils/content/collections'
-import {asSitemapCollection} from "@nuxtjs/sitemap/content";
+import { defineSitemapSchema } from '@nuxtjs/sitemap/content'
 
 const blogSchema = withI18nMeta(z.object({
     title: z.string(),
@@ -257,11 +257,29 @@ const communityPoiSchema = withI18nMeta(z.object({
 
 export default defineContentConfig({
   collections: {
-    ...defineLocalizedCollections('blog', (locale) => asSitemapCollection(asSchemaOrgCollection({
-              type: 'page',
-              source: `blog/${locale}/**/*.md`,
-              schema: blogSchema
-          }))),
+    ...defineLocalizedCollections('blog', (locale) => asSchemaOrgCollection({
+      type: 'page',
+      source: `blog/${locale}/**/*.md`,
+      schema: blogSchema.extend({
+        // Without an `onUrl`, @nuxtjs/sitemap defaults every entry's `loc` to
+        // the content `path`, which is derived from the file location:
+        // `content/blog/en/dev-blog-1.md` becomes `/blog/en/dev-blog-1`. The
+        // real route is `/en/blog/<slug>` and two English slugs do not even
+        // match their filename, so those URLs 404.
+        //
+        // This body is serialised with `fn.toString()` into a Nitro virtual
+        // module and re-evaluated in a scope that holds nothing from this
+        // file — it must not close over `locale` or any import. The locale is
+        // therefore derived from the collection name argument instead.
+        sitemap: defineSitemapSchema({
+          name: `blog_${locale}`,
+          onUrl: (url, entry, collection) => {
+            const loc = collection.split('_').pop()
+            url.loc = `/${loc}/blog/${entry.slug}`
+          }
+        })
+      })
+    })),
     ...defineLocalizedCollections('home_carousel', (locale) => ({
       type: 'data',
       source: `carousel/${locale}/home.json`,
@@ -302,11 +320,21 @@ export default defineContentConfig({
       source: `team-faq/${locale}/*.md`,
       schema: faqSchema
     })),
-    ...defineLocalizedCollections('community_poi', (locale) => asSitemapCollection(asSchemaOrgCollection({
-          type: 'page',
-          source: `community-poi/${locale}/**/*.md`,
-          schema: communityPoiSchema
-        }))),
+    ...defineLocalizedCollections('community_poi', (locale) => asSchemaOrgCollection({
+      type: 'page',
+      source: `community-poi/${locale}/**/*.md`,
+      // Same derived-path problem as the blog collection above; see the
+      // comment there. The serialised body must not close over `locale`.
+      schema: communityPoiSchema.extend({
+        sitemap: defineSitemapSchema({
+          name: `community_poi_${locale}`,
+          onUrl: (url, entry, collection) => {
+            const loc = collection.split('_').pop()
+            url.loc = `/${loc}/community-poi/${entry.slug}`
+          }
+        })
+      })
+    })),
     authors: defineCollection({
       type: 'page',
       source: 'authors/**/*.md',

--- a/content/blog/de/dev-blog-1.md
+++ b/content/blog/de/dev-blog-1.md
@@ -14,7 +14,6 @@ tags:
   - team
 canonical: 'https://onelitefeather.net/de/blog/dev-blog-1-was-wir-verwenden'
 sitemap:
-  loc: '/de/blog/dev-blog-1-was-wir-verwenden'
   lastmod: '2023-10-21'
   changefreq: monthly
   priority: 0.8

--- a/content/blog/de/effizientes-logging-in-paper-plugins.md
+++ b/content/blog/de/effizientes-logging-in-paper-plugins.md
@@ -15,7 +15,6 @@ tags:
 author: phillipp-glanz
 canonical: 'https://onelitefeather.net/de/blog/effizientes-logging-paper-plugins-slf4j-log4j2-grafana-loki'
 sitemap:
-  loc: '/de/blog/effizientes-logging-paper-plugins-slf4j-log4j2-grafana-loki'
   lastmod: '2024-09-29'
   changefreq: monthly
   priority: 0.8

--- a/content/blog/de/everything-you-need-to-know-about-ethanol.md
+++ b/content/blog/de/everything-you-need-to-know-about-ethanol.md
@@ -14,7 +14,6 @@ tags:
 author: phillipp-glanz
 canonical: 'https://onelitefeather.net/de/blog/alles-was-man-ueber-ethanol-wissen-sollte'
 sitemap:
-  loc: '/de/blog/alles-was-man-ueber-ethanol-wissen-sollte'
   lastmod: '2024-07-23'
   changefreq: monthly
   priority: 0.8

--- a/content/blog/de/otis-spielerstammdaten-minecraft.md
+++ b/content/blog/de/otis-spielerstammdaten-minecraft.md
@@ -15,7 +15,6 @@ author: phillipp-glanz
 
 canonical: 'https://onelitefeather.net/de/blog/otis-zentrale-spielerstammdaten-minecraft'
 sitemap:
-  loc: '/de/blog/otis-zentrale-spielerstammdaten-minecraft'
   lastmod: '2025-11-29'
   changefreq: monthly
   priority: 0.8

--- a/content/blog/de/plugins-open-for-adoption.md
+++ b/content/blog/de/plugins-open-for-adoption.md
@@ -14,7 +14,6 @@ tags:
 author: phillipp-glanz
 canonical: 'https://onelitefeather.net/de/blog/wer-moechte-plugins-adoptieren'
 sitemap:
-  loc: '/de/blog/wer-moechte-plugins-adoptieren'
   lastmod: '2025-02-05'
   changefreq: monthly
   priority: 0.8

--- a/content/blog/de/resilienz-im-detail-priorityclasses-pdb-affinitaeten.md
+++ b/content/blog/de/resilienz-im-detail-priorityclasses-pdb-affinitaeten.md
@@ -16,7 +16,6 @@ tags:
 author: phillipp-glanz
 canonical: 'https://onelitefeather.net/de/blog/resilienz-im-detail-priorityclasses-pdb-affinitaeten'
 sitemap:
-  loc: '/de/blog/resilienz-im-detail-priorityclasses-pdb-affinitaeten'
   lastmod: '2026-06-13'
   changefreq: monthly
   priority: 0.8

--- a/content/blog/de/riding-the-rollercoaster-of-automation-with-proxmox-and-ansible.md
+++ b/content/blog/de/riding-the-rollercoaster-of-automation-with-proxmox-and-ansible.md
@@ -15,7 +15,6 @@ tags:
 author: phillipp-glanz
 canonical: 'https://onelitefeather.net/de/blog/mit-proxmox-und-ansible-in-eine-achterbahn-der-automatisierung-vserver'
 sitemap:
-  loc: '/de/blog/mit-proxmox-und-ansible-in-eine-achterbahn-der-automatisierung-vserver'
   lastmod: '2023-10-15'
   changefreq: monthly
   priority: 0.8

--- a/content/blog/de/wenn-ein-server-ausfaellt-cluster-resilienz.md
+++ b/content/blog/de/wenn-ein-server-ausfaellt-cluster-resilienz.md
@@ -15,7 +15,6 @@ tags:
 author: phillipp-glanz
 canonical: 'https://onelitefeather.net/de/blog/wenn-ein-server-ausfaellt-cluster-resilienz'
 sitemap:
-  loc: '/de/blog/wenn-ein-server-ausfaellt-cluster-resilienz'
   lastmod: '2026-06-13'
   changefreq: monthly
   priority: 0.8


### PR DESCRIPTION
Implements **PR-06** from the best-practice audit (`CNT-01`), on the non-deprecated API.

## The problem

Every English blog post sat in `sitemap.xml` under a URL that 404s.

Without an `onUrl`, `@nuxtjs/sitemap` defaults each entry's `loc` to the content `path`, which is derived from the **file location** — `content/blog/en/dev-blog-1.md` becomes `/blog/en/dev-blog-1`. The real route is `/en/blog/<slug>`, and two English slugs do not even match their filename:

| file | slug |
|---|---|
| `dev-blog-1` | `dev-blog-1-what-we-using` |
| `otis-regular-data-minecraft` | `otis-central-player-data-minecraft` |

All 8 German posts carry hand-written `sitemap.loc` frontmatter that happens to be correct. **None of the 7 English ones do.**

## Measured before the change

```
sitemap says   404  /blog/en/dev-blog-1
real route     200  /en/blog/dev-blog-1-what-we-using   (absent from the sitemap)
```

## The fix

Uses `defineSitemapSchema()` in the collection schema instead of the `asSitemapCollection()` wrapper, which v8 deprecates — the build warned about it on every run. **That warning is now gone.**

```ts
schema: blogSchema.extend({
  sitemap: defineSitemapSchema({
    name: `blog_${locale}`,
    onUrl: (url, entry, collection) => {
      const loc = collection.split('_').pop()
      url.loc = `/${loc}/blog/${entry.slug}`
    }
  })
})
```

The `onUrl` body is serialised with `fn.toString()` into a Nitro virtual module and re-evaluated in a scope holding **nothing** from `content.config.ts`. It must not close over `locale` or any import — hence deriving the locale from the collection-name argument.

## Also fixes `community_poi`

The same defect existed in the collection added by #156 earlier today, which merged before a build gate was in place. Its POI pages had the identical file-path `loc`. Fixed the same way.

## German posts

The now-redundant `sitemap.loc` line is removed from all 8 — each was verified to equal the derived `/de/blog/<slug>` **exactly**, so the output is byte-identical.

`lastmod`, `changefreq` and `priority` are **kept**. The original plan called for dropping the whole block; that would have discarded real SEO signal for no benefit.

## Verification

| Check | Result |
|---|---|
| All 28 URLs in the English sitemap | **200** each |
| German sitemap | unchanged |
| `asSitemapCollection() is deprecated` warning | gone |
| Built SQL dump | `sitemap` column still declared on `_content_blog_en` |
| Quality ratchet | 404 / 83 / 41, no regression |

## Note

`asSchemaOrgCollection()` is deprecated too and still warns. Converting it to `defineSchemaOrgSchema()` is a separate concern and not mixed in here.

If #194 lands first, the ratchet pins `.nuxt/` itself; this branch was measured with a manual reset to match.

Refs: `CNT-01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s