### PR TITLE
fix(image): derive the provider from the build context instead of a dashboard variable

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,13 +3,30 @@ import {defineOrganization} from 'nuxt-schema-org/schema'
 import tailwindcss from "@tailwindcss/vite";
 import pkg from './package.json' assert {type: 'json'}
 
-// Image provider is chosen at build time from the NUXT_IMAGE_PROVIDER build
-// variable, set per Wrangler environment in Cloudflare Workers Builds. The
-// `production` environment sets it to `cloudflare` to route images through
-// the img.onelitefeather.net proxy; preview/local builds leave it unset and
-// fall back to `none`, serving the originals straight from the deploy's own
-// /public — the proxy only knows the live site and would 404 branch assets.
-const imageProvider = process.env.NUXT_IMAGE_PROVIDER === 'cloudflare'
+// Image provider, chosen at build time.
+//
+// Most images referenced from content/ do NOT exist in this repository — they
+// live only behind the img.onelitefeather.net proxy (5 of the 6 paths under
+// /images/ referenced by content/ have no file in public/). With the `none`
+// provider those paths are emitted verbatim and 404 for every visitor.
+//
+// This used to depend solely on a NUXT_IMAGE_PROVIDER build variable
+// configured in the Cloudflare dashboard, outside version control. When that
+// variable is absent the fallback to `none` is silent, and the result is a
+// deploy that renders without images. That is exactly what happened once
+// Workers Builds rebuilt `main` after months without a deploy.
+//
+// So the default is now derived from the build context Cloudflare injects
+// itself (WORKERS_CI=1 on Workers Builds — see
+// developers.cloudflare.com/workers/ci-cd/builds/configuration/): anything
+// built by Cloudflare is published and must use the proxy. Local and
+// GitHub Actions builds keep `none`, which serves whatever is in public/.
+//
+// NUXT_IMAGE_PROVIDER still wins when set explicitly, so a Workers build can
+// be forced onto `none` — scripts/check-image-assets.mjs then refuses the
+// build unless every referenced image really is in public/.
+const isCloudflareBuild = process.env.WORKERS_CI === '1'
+const imageProvider = (process.env.NUXT_IMAGE_PROVIDER ?? (isCloudflareBuild ? 'cloudflare' : 'none')) === 'cloudflare'
   ? 'cloudflare'
   : 'none'
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "homepage": "https://github.com/TheMeinerLP/launchpad#readme",
   "license": "MIT",
   "scripts": {
-    "build": "nuxi build",
+    "build": "node scripts/check-image-assets.mjs && nuxi build",
+    "check:images": "node scripts/check-image-assets.mjs",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/scripts/check-image-assets.mjs
+++ b/scripts/check-image-assets.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Refuses a published build that cannot serve its own images.
+ *
+ * Most images referenced from content/ are not in this repository; they live
+ * behind the img.onelitefeather.net proxy and are only reachable when
+ * @nuxt/image runs with the `cloudflare` provider. Under `none` those paths
+ * are emitted verbatim and 404.
+ *
+ * Runs before every build. It fails only when a build is both published and
+ * unable to resolve an image — a local or GitHub Actions build stays a
+ * warning, because nothing there is served to visitors.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, join } from 'node:path'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const CONTENT = join(ROOT, 'content')
+const PUBLIC = join(ROOT, 'public')
+
+// Mirrors the resolution in nuxt.config.ts. Keep the two in step.
+const isCloudflareBuild = process.env.WORKERS_CI === '1'
+const provider = (process.env.NUXT_IMAGE_PROVIDER ?? (isCloudflareBuild ? 'cloudflare' : 'none')) === 'cloudflare'
+  ? 'cloudflare'
+  : 'none'
+
+/** Every /images/... path referenced by a content file. */
+function collectReferences(dir, found = new Map()) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      collectReferences(full, found)
+      continue
+    }
+    if (!/\.(md|json|ya?ml)$/.test(entry)) continue
+    const text = readFileSync(full, 'utf8')
+    for (const match of text.matchAll(/["'](\/images\/[^"']+)["']/g)) {
+      const path = match[1]
+      if (!found.has(path)) found.set(path, [])
+      found.get(path).push(full.replace(`${ROOT}/`, ''))
+    }
+  }
+  return found
+}
+
+const references = existsSync(CONTENT) ? collectReferences(CONTENT) : new Map()
+const missing = [...references.entries()].filter(([path]) => !existsSync(join(PUBLIC, path)))
+
+console.log(`\nImage assets: provider "${provider}", ${references.size} referenced, ${missing.length} not in public/.`)
+
+if (missing.length === 0) {
+  console.log('Every referenced image resolves locally.\n')
+  process.exit(0)
+}
+
+if (provider === 'cloudflare') {
+  console.log('Served through img.onelitefeather.net — not required locally.\n')
+  process.exit(0)
+}
+
+for (const [path, sources] of missing) {
+  console.log(`  ${path}\n    referenced by ${sources.join(', ')}`)
+}
+
+if (!isCloudflareBuild) {
+  console.log('\nProvider is "none" and these files are absent, so they will 404 in this'
+    + '\nbuild. Harmless locally and in GitHub Actions, where nothing is served to'
+    + '\nvisitors — this is a warning, not a failure.\n')
+  process.exit(0)
+}
+
+console.log('\nThis build runs on Cloudflare Workers Builds and its output is published,'
+  + '\nbut the provider is "none" and the images above are not in public/. Visitors'
+  + '\nwould get 404s. Either drop the NUXT_IMAGE_PROVIDER override so the build'
+  + '\ndefaults to "cloudflare", or commit the files to public/.\n')
+process.exit(1)


### PR DESCRIPTION
**Production is currently serving pages without images.** This restores them and stops it recurring.

## What broke

**5 of the 6 images referenced from `content/` do not exist in this repository.** They live only behind the `img.onelitefeather.net` proxy, which `@nuxt/image` uses only with the `cloudflare` provider. Under `none`, those paths are emitted verbatim and 404.

The provider depended on a single `NUXT_IMAGE_PROVIDER` build variable configured in the Cloudflare dashboard — outside version control — and the fallback to `none` was **silent**.

Verified by building the same commit both ways:

| Build | Provider in bundle | Result |
|---|---|---|
| without the variable | `provider:"none"` | `/images/carousel/carousel_spawn.png` → **404** |
| `NUXT_IMAGE_PROVIDER=cloudflare` | `provider:"cloudflare"` | proxy → **200** |

The images themselves are fine — `img.onelitefeather.net/images/carousel/carousel_spawn.png` returns 200, including through the `cdn-cgi` transform pipeline.

## The dependency updates did not cause this

They were the occasion, not the cause.

The tag-driven deploy path has **never fired** — its `v*` glob does not match the `onelitefeather.net-v*` tags release-please cuts (finding `OPS-01`, confirmed live when v1.2.0 was tagged today and `promote-release.yml` did not run). So nothing had been merged to `main` since May, and production kept serving a months-old build made while the variable was still set.

Today's merges triggered the first Workers Builds rebuild since then, and that one ran without it. **Any commit would have done the same.**

Proof that today's build is live: `/de/community-poi`, added this morning in #156, responds 200.

## The fix

Derive the default from what Cloudflare injects itself — [`WORKERS_CI=1` on Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/#environment-variables):

```ts
const isCloudflareBuild = process.env.WORKERS_CI === '1'
const imageProvider = (process.env.NUXT_IMAGE_PROVIDER ?? (isCloudflareBuild ? 'cloudflare' : 'none')) === 'cloudflare'
  ? 'cloudflare' : 'none'
```

Anything Cloudflare builds is published and must use the proxy. Local and GitHub Actions builds keep `none` and serve `public/`.

`NUXT_IMAGE_PROVIDER` **still wins when set**, so the dashboard variable keeps working and nothing has to be changed there. Setting it remains a good idea for explicitness — but the deploy no longer depends on it.

### Note on preview builds

The old comment justified `none` for previews because "the proxy only knows the live site and would 404 branch assets". That trade was backwards: under `none` previews showed **no** images at all, since almost none are in `public/`. With `cloudflare` they show every existing image; only a brand-new asset added on a branch would be missing until it reaches the proxy.

## The guard

`scripts/check-image-assets.mjs`, wired into `pnpm build`, covers the case where the override is used. It lists every referenced image missing from `public/` and **fails the build when the output is published and the provider cannot reach them**. Locally and in GitHub Actions it warns instead — nothing there is served to visitors.

Verified in all four combinations:

| Context | Provider | Behaviour |
|---|---|---|
| local, no override | `none` | warns, exit 0 |
| `WORKERS_CI=1` | `cloudflare` | passes, `provider:"cloudflare"` in bundle |
| `WORKERS_CI=1`, forced `none` | `none` | **refuses, exit 1** |
| local, forced `cloudflare` | `cloudflare` | passes |

## Still worth checking

You mentioned Cloudflare showing *"Update your wrangler config file with these changes to keep your local development environment in sync."* This PR does not address that — I never saw which keys it lists.

It matters independently: `nitro.cloudflare.deployConfig: true` makes Nitro generate `wrangler.json` on every build, and the generated file contains only the D1 binding, the assets binding and compatibility flags — **no `vars`, no `env` section**. If runtime variables or bindings are maintained in the dashboard, a deploy could overwrite them. Worth comparing that message against the generated file.

Counts unchanged (404 / 83 / 41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s