### PR TITLE
fix(blog): stop share links pointing at /undefined/blog/<slug>

### DIFF
--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -22,6 +22,19 @@ const LazySocialMediaShare = defineAsyncComponent(() => import('~/components/fea
 // publishes via useSetI18nParams.
 const { title } = useArticleSeo(blog, authors)
 
+// Absolute URL for the share buttons. Built here rather than inline in the
+// template: `locale` is a ref and a template auto-unwraps it, so the
+// `locale.value` this used to interpolate evaluated to `undefined` — every
+// share link and the copy button pointed at /undefined/blog/<slug>.
+// Base URL resolution mirrors useArticleSeo: runtimeConfig.public.siteUrl is
+// only set inside the $production block, so fall back to the site config,
+// which is populated in every environment.
+const site = useSiteConfig()
+const shareUrl = computed(() => {
+  const base = (config.public as { siteUrl?: string }).siteUrl || site.url
+  return `${base}/${locale.value}/blog/${blog.value?.slug ?? ''}`
+})
+
 // Force the per-article title + description into the document head so social
 // embeds (og:title / og:description) use the real article values — with
 // umlauts. Without this, @nuxtjs/seo's route-derived fallback wins and emits
@@ -121,7 +134,7 @@ useHead(() => {
         <section class="mt-8 border-t border-neutral-200 dark:border-neutral-800 pt-6" :aria-label="t('article.share')">
           <h2 class="sr-only">{{ t('article.share') }}</h2>
           <LazySocialMediaShare
-            :url="`${config.public.siteUrl}/${locale.value}/blog/${blog?.slug || ''}`"
+            :url="shareUrl"
             :title="blog?.title"
             :description="blog?.description || ''"
             :is-large-page="['alles-was-man-ueber-ethanol-wissen-sollte', 'riding-the-rollercoaster-of-automation-with-proxmox-and-ansible', 'plugins-open-for-adoption', 'effizientes-logging-in-paper-plugins', 'dev-blog-1'].includes(blog?.slug)"

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
   "eslintErrors": 404,
   "eslintWarnings": 83,
-  "typeErrors": 41
+  "typeErrors": 40
 }


### PR DESCRIPTION
Implements **PR-05** (`ARCH-01`, `I18N-01`).

## The bug

`locale` comes from `useI18n()` and is a **ref**. A template auto-unwraps refs, so the `locale.value` interpolated into the share URL evaluated to `undefined`:

```vue
:url="`${config.public.siteUrl}/${locale.value}/blog/${blog?.slug || ''}`"
```

That prop feeds **every** platform href in `SocialMediaShare.vue` — Facebook, X, Bluesky, LinkedIn, Reddit, Telegram, WhatsApp, email — plus the copy-link button. Every one of them shared:

```
https://onelitefeather.net/undefined/blog/<slug>
```

The typecheck named it exactly, and had done since the gate landed in #191:

```
pages/blog/[...slug].vue(124,54): error TS2551:
  Property 'value' does not exist on type '"de" | "en"'. Did you mean 'valueOf'?
```

## The fix

Moves the URL into a `computed` in `<script setup>`, where `locale.value` **is** the correct form. Same reason `pages/team/[slug].vue` writes `` `/${locale}/team` `` in its template but uses `.value` in its script — the distinction is the template's auto-unwrap, not the ref itself.

## Second half of the defect

`runtimeConfig.public.siteUrl` is declared **only inside the `$production` block**. Outside production the URL began `undefined/...` even with the locale corrected — two independent sources of `undefined` in one string.

Resolution now mirrors `useArticleSeo.ts:33`: runtime config first, site config as fallback, and the site config is populated in every environment.

```ts
const site = useSiteConfig()
const shareUrl = computed(() => {
  const base = (config.public as { siteUrl?: string }).siteUrl || site.url
  return `${base}/${locale.value}/blog/${blog.value?.slug ?? ''}`
})
```

The underlying `$production` duplication is `ARCH-02` and untouched here.

## Verification

| Check | Result |
|---|---|
| Type errors | **41 → 40**, none left in this file |
| Baseline | lowered to 40 and committed |
| Rendered page | no URL containing `undefined` |
| Build | passes |

One limitation worth stating: `SocialMediaShare` is loaded via `defineAsyncComponent`, so its links are not in the SSR HTML and I could not assert on the final `href` values from a server response. The proof here is the type system plus the computed being evaluated in the right scope — not an end-to-end click.

Refs: `ARCH-01`, `I18N-01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s