### PR TITLE
fix(styles): define the numeric brand scale the components already use

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -18,6 +18,31 @@
     --color-brand-purple:   #91268F; /* violett */
     --color-white:          #FFFFFF;
 
+    /* Numeric brand ramp.
+       Components already addressed brand colours this way (text-brand-900,
+       bg-brand-100, from-brand-500) across 38 call sites, but no such scale
+       existed, so every one of them compiled to nothing.
+
+       Derived from --color-brand-primary rather than picked by eye: that
+       colour is hsl(232, 55%, 36%), and each step keeps hue and saturation
+       while moving lightness. Step 500 is the base value itself, so
+       `bg-brand-500` and `bg-brand-primary` render identically — a test
+       enforces that.
+
+       The lightness curve is conventional (96 / 91 / 82 / 70 / 54 / 36 / 30 /
+       24 / 19 / 14); if the brand guide specifies exact tints, replace these
+       values — the call sites and the test stay valid either way. */
+    --color-brand-50:       #EFF1FA;
+    --color-brand-100:      #DCDFF5;
+    --color-brand-200:      #B8BFEA;
+    --color-brand-300:      #8994DC;
+    --color-brand-400:      #4A5BCA;
+    --color-brand-500:      #2A388F;
+    --color-brand-600:      #232E76;
+    --color-brand-700:      #1C255F;
+    --color-brand-800:      #161D4B;
+    --color-brand-900:      #101637;
+
     /* Derived neutrals (UI) */
     --color-bg:             light-dark(#ffffff, #0b1020);
     --color-surface:        light-dark(#ffffff, #11162a);

--- a/tests/design-system/brand-scale.spec.ts
+++ b/tests/design-system/brand-scale.spec.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo, repoRoot } from '../helpers/sources'
+
+/**
+ * Components address brand colours on a numeric scale — `text-brand-900`,
+ * `bg-brand-100`, `from-brand-500`. Tailwind mints a utility per `--color-*`
+ * entry in `@theme`, so every step used has to be declared there or the class
+ * compiles to nothing and ships invisible.
+ *
+ * Rather than forbidding the scale (the usages range 50–900 and clearly want
+ * gradations; collapsing them onto two tokens would flatten the design), this
+ * asserts the weaker and more useful rule: whatever step the code names must
+ * exist. That catches both a missing scale and a single typo'd step.
+ */
+
+const SOURCE_DIRS = [
+  'components',
+  'pages',
+  'layouts',
+]
+
+/** Utility prefixes that resolve against the colour namespace. */
+const COLOUR_PREFIX = 'bg|text|ring|ring-offset|border|outline|from|via|to|shadow|fill|stroke|decoration|divide|accent|caret'
+
+const USED_STEP = new RegExp(`\\b(?:${COLOUR_PREFIX})-brand-(\\d+)\\b`, 'g')
+
+function themeTokens(): Set<string> {
+  const css = readFileSync(join(repoRoot, 'assets/css/tailwind.css'), 'utf8')
+  const names = [...css.matchAll(/--color-([a-z0-9-]+)\s*:/g)]
+    .map((match) => match[1])
+    .filter((name): name is string => name !== undefined)
+  return new Set(names)
+}
+
+function templateFiles(): string[] {
+  return collectSourceFiles(SOURCE_DIRS, ['.vue']).concat([join(repoRoot, 'error.vue')])
+}
+
+describe('numeric brand scale', () => {
+  const usages = new Map<string, string[]>()
+  for (const file of templateFiles()) {
+    const text = readFileSync(file, 'utf8')
+    for (const match of text.matchAll(USED_STEP)) {
+      const step = match[1]
+      if (step === undefined) continue
+      const seen = usages.get(step) ?? []
+      seen.push(relativeToRepo(file))
+      usages.set(step, seen)
+    }
+  }
+
+  it('declares every step the components use', () => {
+    const tokens = themeTokens()
+    const missing = [...usages.keys()]
+      .filter((step) => !tokens.has(`brand-${step}`))
+      .sort((a, b) => Number(a) - Number(b))
+      .map((step) => `brand-${step} (used in ${usages.get(step)?.length} file(s))`)
+    expect(missing).toEqual([])
+  })
+
+  it('keeps 500 as the base step, matching brand-primary', () => {
+    // The scale is derived from --color-brand-primary. If 500 drifts away from
+    // it, `from-brand-500` and `bg-brand-primary` stop matching where both are
+    // used on the same surface.
+    const css = readFileSync(join(repoRoot, 'assets/css/tailwind.css'), 'utf8')
+    const primary = /--color-brand-primary:\s*([^;]+);/.exec(css)?.[1]?.trim().toLowerCase()
+    const step500 = /--color-brand-500:\s*([^;]+);/.exec(css)?.[1]?.trim().toLowerCase()
+    expect(step500).toBe(primary)
+  })
+})


### PR DESCRIPTION
> **Stacked on #210** (which is stacked on #209). Merge in order; GitHub retargets each automatically.

Implements **PR-12** (`TW-04`), test-first.

## The gap

38 call sites address brand colours as `text-brand-900`, `bg-brand-100`, `from-brand-500`. **No such scale existed** — `@theme` declared only `brand-primary/secondary/accent/orange/purple`. Every one of those classes compiled to nothing and shipped invisible.

## Two commits, red then green

**`0c7eff9` — the test, failing.** All ten steps reported missing:

```
brand-50  (used in 2 file(s))     brand-500 (used in 3 file(s))
brand-100 (used in 6 file(s))     brand-600 (used in 4 file(s))
brand-200 (used in 3 file(s))     brand-700 (used in 2 file(s))
brand-300 (used in 4 file(s))     brand-800 (used in 4 file(s))
brand-400 (used in 4 file(s))     brand-900 (used in 6 file(s))
```

**`2854b2b` — the scale.** Test green, and the classes verified in the built CSS.

## Why define the scale rather than remove it

The audit offered both. Collapsing 38 usages onto the two existing tokens would have flattened real contrast relationships — `text-brand-900` sits on light surfaces, `text-brand-100` on dark ones. The steps are used deliberately.

## The values are derived, not picked

`--color-brand-primary` is `hsl(232, 55%, 36%)`. Each step keeps hue and saturation and moves lightness along a conventional curve:

| | | | |
|---|---|---|---|
| `50` `#EFF1FA` | `100` `#DCDFF5` | `200` `#B8BFEA` | `300` `#8994DC` |
| `400` `#4A5BCA` | **`500` `#2A388F`** | `600` `#232E76` | `700` `#1C255F` |
| `800` `#161D4B` | `900` `#101637` | | |

Step 500 **is** the base value, so `bg-brand-500` and `bg-brand-primary` render identically — a second test enforces that, so the two cannot drift apart.

> ⚠️ **This is the one judgement call in the PR.** The lightness curve is conventional, not taken from a brand guide. If exact tints are specified somewhere, replace the ten values — the call sites and both tests stay valid. Worth a look from whoever owns the brand.

## The test asserts the weaker rule on purpose

Not "no numeric scale" but "every step named must exist". That permits the scale, still catches a typo'd step later, and does not encode my choice between the two options as a rule.

Ratchet unchanged: 404 / 83 / 40. Suite: 8 tests, 2 files.

Refs: `TW-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s