### PR TITLE
fix(team): return a real 404 for unknown profile slugs

### DIFF
--- a/composables/useTeamProfile.ts
+++ b/composables/useTeamProfile.ts
@@ -1,3 +1,4 @@
+import { createError } from '#imports'
 import { useContentRepository } from '~/composables/useContentRepository'
 import type { Locale } from '~/utils/content/collections'
 import type { TeamDocument, TeamMember } from '~/types/team'
@@ -28,6 +29,19 @@ export async function useTeamProfile(slugOverride?: string) {
     const list = teamDoc.value?.members || []
     return (list as TeamMember[]).find((m) => m.slug === slug.value) || null
   })
+
+  // A slug matching no member has to surface a real 404. Rendering the
+  // placeholder answered HTTP 200 for every string anyone appended to /team/,
+  // an unbounded space of indexable thin pages.
+  //
+  // Thrown here rather than inside the fetcher, and after the await above, so
+  // the document is resolved and `member` is final — the ordering
+  // useBlogContent uses. `fatal: true` is what makes Nuxt replace the route
+  // with the error page; without it the response stays 200 and the soft 404
+  // survives.
+  if (slug.value && !member.value) {
+    throw createError({ statusCode: 404, statusMessage: 'Team member not found', fatal: true })
+  }
 
   // Profile hero renders the head at 96px in a 2x density box. Requesting
   // a 256px upstream render leaves headroom for retina and lets the

--- a/tests/routes/soft-404.spec.ts
+++ b/tests/routes/soft-404.spec.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * A page that renders "not found" text while answering HTTP 200 is a soft 404.
+ * Search engines index it, so an unbounded URL space — every possible slug —
+ * turns into thin duplicate content, and monitoring never sees an error.
+ *
+ * The correct pattern is already in the repository: useBlogContent resolves
+ * the article, then throws `createError({ statusCode: 404, fatal: true })`
+ * when the slug matched nothing. useTeamProfile resolved a member the same way
+ * and simply rendered a placeholder.
+ *
+ * On what this asserts: the status code only exists once a real server has
+ * handled a request, so the honest test is end-to-end. I tried that first —
+ * @nuxt/test-utils with `server: true` — and abandoned it: the build hit a
+ * Rollup sourcemap conflict, and after working around that every request came
+ * back unreachable, including the positive control. 64 seconds per run for a
+ * setup that fragile is a bad trade.
+ *
+ * So this checks the weaker, structural property instead: a composable that
+ * resolves a route slug must contain a 404 `createError`. It cannot prove the
+ * response code, and it would not catch the throw being unreachable. It does
+ * catch a new detail page shipping without the guard at all, which is the
+ * mistake that actually happened.
+ */
+
+const SLUG_LOOKUP = /route\.params\.slug/
+const NOT_FOUND_THROW = /createError\(\{[^}]*statusCode:\s*404/s
+
+describe('slug-resolving composables', () => {
+  const composables = collectSourceFiles(['composables'], ['.ts'])
+    .filter((file) => SLUG_LOOKUP.test(readFileSync(file, 'utf8')))
+
+  it('finds the composables that resolve a slug', () => {
+    // Without this the suite passes vacuously the moment the pattern changes
+    // — for instance if a page switches to useRoute().params.id.
+    expect(composables.length).toBeGreaterThan(0)
+  })
+
+  it('each throws a 404 when the slug matches nothing', () => {
+    const missing = composables
+      .filter((file) => !NOT_FOUND_THROW.test(readFileSync(file, 'utf8')))
+      .map(relativeToRepo)
+    expect(missing).toEqual([])
+  })
+
+  it('uses fatal: true so the error page replaces the route', () => {
+    // Without `fatal`, Nuxt surfaces the error inline and the route still
+    // answers 200 — the soft 404 survives the fix.
+    const nonFatal = composables
+      .filter((file) => {
+        const text = readFileSync(file, 'utf8')
+        const call = /createError\(\{[^}]*statusCode:\s*404[^}]*\}\)/s.exec(text)?.[0]
+        return call !== undefined && !/fatal:\s*true/.test(call)
+      })
+      .map(relativeToRepo)
+    expect(nonFatal).toEqual([])
+  })
+})
+
+describe('the pattern this copies', () => {
+  it('matches how useBlogContent already does it', () => {
+    // Pins the reference implementation: if the blog guard is ever removed,
+    // this test should fail rather than quietly lower the bar for everyone.
+    const blog = collectSourceFiles(['composables'], ['.ts'])
+      .find((file) => basename(file) === 'useBlogContent.ts')
+    expect(blog).toBeDefined()
+    const text = readFileSync(blog as string, 'utf8')
+    expect(NOT_FOUND_THROW.test(text)).toBe(true)
+    expect(/fatal:\s*true/.test(text)).toBe(true)
+  })
+})


### PR DESCRIPTION
Implements **PR-18** (`SEO-03`, `ARCH-04`), test-first. Single PR against `main` — after #215 I am not stacking unless a change genuinely depends on an unmerged one.

## The defect

`/de/team/<anything>` answered **HTTP 200** and rendered a placeholder. Every string anyone appended to `/team/` was an indexable page — an unbounded space of thin duplicate content, and monitoring never saw an error.

`useBlogContent` already handled its own slug correctly. `useTeamProfile` resolved a member the same way and just rendered nothing.

## Verified against a running server

With a positive control, so a 404 cannot merely mean the route is broken:

| Route | Status | |
|---|---|---|
| `/de/team/themeinerlp` | **200** | real member, unchanged |
| `/de/team/definitely-not-a-member` | **404** | ← the fix |
| `/de/blog/definitely-not-an-article` | 404 | already correct |
| `/de/team` | 200 | index untouched |

`fatal: true` is the load-bearing part: without it Nuxt renders the error inline and the response stays 200, so the soft 404 would survive the fix. A test asserts it explicitly.

## About the test — and what I gave up on

I wrote the end-to-end version first, with `@nuxt/test-utils` and `server: true`, because **the status code is the whole point and only a real request can observe it.** I abandoned it after two failures:

1. the test build hit a Rollup sourcemap conflict on `pages/team/[slug].vue`
2. with sourcemaps disabled, every request came back unreachable — **including the positive control**, so the harness was broken, not the route

64 seconds per run for something that fragile is a bad trade. The committed test checks the structural property instead: a composable resolving `route.params.slug` must contain a 404 `createError` with `fatal: true`.

**It is honestly weaker.** It cannot prove a response code and would not catch the throw being unreachable. It does catch a new detail page shipping without the guard — the mistake that actually happened here. The real evidence is the status table above, from `curl` against `pnpm dev`, which took seconds.

A fourth test pins `useBlogContent` as the reference implementation, so removing its guard fails rather than quietly lowering the bar.

Suite: 15 tests, 4 files. Ratchet unchanged: 357 / 48 / 31. Build green.

Refs: `SEO-03`, `ARCH-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s