### PR TITLE
fix(i18n): add the four message keys the Prose components ask for

### DIFF
--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -354,9 +354,18 @@
             "q": "Wie installiere ich den Mod?",
             "a": "Du brauchst den Fabric-Loader passend zur Minecraft-Version und legst die Litematica-JAR (sowie die Abhängigkeit MaLiLib) in den mods/-Ordner. Beim Start in den Mods-Einstellungen prüfen, dass beide aktiv sind.",
             "links": [
-              { "label": "Litematica auf Modrinth", "href": "https://modrinth.com/mod/litematica" },
-              { "label": "MaLiLib auf Modrinth", "href": "https://modrinth.com/mod/malilib" },
-              { "label": "Fabric Loader", "href": "https://modrinth.com/mod/fabric-api" }
+              {
+                "label": "Litematica auf Modrinth",
+                "href": "https://modrinth.com/mod/litematica"
+              },
+              {
+                "label": "MaLiLib auf Modrinth",
+                "href": "https://modrinth.com/mod/malilib"
+              },
+              {
+                "label": "Fabric Loader",
+                "href": "https://modrinth.com/mod/fabric-api"
+              }
             ]
           },
           {
@@ -371,7 +380,10 @@
             "q": "Welche Litematica-Version brauche ich?",
             "a": "Pro Schematic geben wir die empfohlene Litematica-Version (und passende Minecraft-Version) direkt an der Datei an. Halte dich an diese Kombination – ältere oder neuere Litematica-Versionen können Blöcke unterschiedlich serialisieren und das Hologramm verschiebt sich oder fehlt komplett.",
             "links": [
-              { "label": "Alle Litematica-Versionen auf Modrinth", "href": "https://modrinth.com/mod/litematica/versions" }
+              {
+                "label": "Alle Litematica-Versionen auf Modrinth",
+                "href": "https://modrinth.com/mod/litematica/versions"
+              }
             ]
           },
           {
@@ -396,5 +408,11 @@
     "detail": {
       "back": "Zur POI-Übersicht"
     }
+  },
+  "content": {
+    "file": "Datei {filename}",
+    "codeIn": "Code in {language}",
+    "codeblock": "Codeblock",
+    "permalinkToHeading": "Permalink zur Überschrift {id}"
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -354,9 +354,18 @@
             "q": "How do I install the mod?",
             "a": "You need the Fabric loader for your Minecraft version and drop the Litematica JAR (plus its dependency MaLiLib) into the mods/ folder. After launch, check the mods menu to confirm both are active.",
             "links": [
-              { "label": "Litematica on Modrinth", "href": "https://modrinth.com/mod/litematica" },
-              { "label": "MaLiLib on Modrinth", "href": "https://modrinth.com/mod/malilib" },
-              { "label": "Fabric Loader", "href": "https://modrinth.com/mod/fabric-api" }
+              {
+                "label": "Litematica on Modrinth",
+                "href": "https://modrinth.com/mod/litematica"
+              },
+              {
+                "label": "MaLiLib on Modrinth",
+                "href": "https://modrinth.com/mod/malilib"
+              },
+              {
+                "label": "Fabric Loader",
+                "href": "https://modrinth.com/mod/fabric-api"
+              }
             ]
           },
           {
@@ -371,7 +380,10 @@
             "q": "Which Litematica version do I need?",
             "a": "Each schematic lists the recommended Litematica version (and matching Minecraft version) right next to the file. Stick to that combination — older or newer Litematica releases can serialise blocks differently, which shifts or breaks the hologram.",
             "links": [
-              { "label": "All Litematica versions on Modrinth", "href": "https://modrinth.com/mod/litematica/versions" }
+              {
+                "label": "All Litematica versions on Modrinth",
+                "href": "https://modrinth.com/mod/litematica/versions"
+              }
             ]
           },
           {
@@ -396,5 +408,11 @@
     "detail": {
       "back": "Back to POI overview"
     }
+  },
+  "content": {
+    "file": "File {filename}",
+    "codeIn": "Code in {language}",
+    "codeblock": "Code block",
+    "permalinkToHeading": "Permalink to heading {id}"
   }
 }

--- a/tests/i18n/message-keys.spec.ts
+++ b/tests/i18n/message-keys.spec.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo, repoRoot } from '../helpers/sources'
+
+/**
+ * A message key that exists in neither locale does not fail loudly. vue-i18n
+ * echoes the key itself, or — as here — the call site guards with `te()` and
+ * falls back to a hardcoded English string, so German pages quietly ship
+ * English text.
+ *
+ * Keys reach `t()` two ways in this codebase, and checking only the first is
+ * how the four missing ones stayed missing:
+ *
+ *     t('article.share')                    // literal argument
+ *     const key = 'content.file'            // via a local constant,
+ *     te(key) ? t(key, { … }) : 'File …'    // which is what Prose* does
+ */
+
+const SOURCE_DIRS = [
+  'components',
+  'pages',
+  'layouts',
+  'composables',
+]
+
+/** Dotted identifiers passed directly to t/$t/te. */
+const DIRECT_CALL = /\$?\b(?:t|te)\(\s*[`'"]([a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)+)[`'"]/g
+
+/** `const key = 'a.b'` — captured so a later t(key) can be resolved. */
+const KEY_CONST = /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*[`'"]([a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)+)[`'"]/g
+
+/** t(identifier) / te(identifier) — the name is resolved against KEY_CONST. */
+const INDIRECT_CALL = /\$?\b(?:t|te)\(\s*([A-Za-z_$][\w$]*)\s*[,)]/g
+
+function flatten(value: unknown, prefix = ''): string[] {
+  if (typeof value !== 'object' || value === null) return [prefix]
+  return Object.entries(value as Record<string, unknown>)
+    .flatMap(([key, inner]) => flatten(inner, prefix ? `${prefix}.${key}` : key))
+}
+
+function localeKeys(locale: string): Set<string> {
+  const file = join(repoRoot, `i18n/locales/${locale}.json`)
+  return new Set(flatten(JSON.parse(readFileSync(file, 'utf8'))))
+}
+
+/** Every message key a file asks for, both call styles resolved. */
+function keysUsedIn(text: string): string[] {
+  const found = new Set<string>()
+  for (const match of text.matchAll(DIRECT_CALL)) {
+    if (match[1] !== undefined) found.add(match[1])
+  }
+  // One name can be bound several times in one file — ProsePre declares
+  // `const key` three times, once per block. Keeping only the last binding
+  // hid two of the four missing keys, so every binding is collected and all
+  // of them count as used. Slightly over-approximate by design: a key that
+  // exists is never reported, and this errs toward asking for more keys, not
+  // fewer.
+  const constants = new Map<string, Set<string>>()
+  for (const match of text.matchAll(KEY_CONST)) {
+    const [, name, key] = match
+    if (name === undefined || key === undefined) continue
+    const bound = constants.get(name) ?? new Set<string>()
+    bound.add(key)
+    constants.set(name, bound)
+  }
+  for (const match of text.matchAll(INDIRECT_CALL)) {
+    const name = match[1]
+    if (name === undefined) continue
+    for (const key of constants.get(name) ?? []) found.add(key)
+  }
+  return [...found]
+}
+
+describe('message keys', () => {
+  const de = localeKeys('de')
+  const en = localeKeys('en')
+  const usage = new Map<string, string[]>()
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
+    for (const key of keysUsedIn(readFileSync(file, 'utf8'))) {
+      usage.set(key, (usage.get(key) ?? []).concat(relativeToRepo(file)))
+    }
+  }
+
+  it('resolves both call styles, including a name bound more than once', () => {
+    // The indirect style is what the four missing keys used; without resolving
+    // it this suite would report a clean tree while German pages show English.
+    // The repeated `key` binding is the shape ProsePre actually has — an
+    // earlier version of this helper kept only the last one and so found two
+    // of the four.
+    const sample = `
+      const label = t('article.share')
+      if (a) {
+        const key = 'content.file'
+        const text = te(key) ? t(key, { filename }) : 'File'
+      }
+      if (b) {
+        const key = 'content.codeIn'
+        const text = te(key) ? t(key, { language }) : 'Code in'
+      }
+    `
+    expect(keysUsedIn(sample).sort()).toEqual(['article.share', 'content.codeIn', 'content.file'])
+  })
+
+  it('finds keys in use', () => {
+    expect(usage.size).toBeGreaterThan(50)
+  })
+
+  it('every key used exists in German', () => {
+    const missing = [...usage.keys()].filter((key) => !de.has(key)).sort()
+    expect(missing).toEqual([])
+  })
+
+  it('every key used exists in English', () => {
+    const missing = [...usage.keys()].filter((key) => !en.has(key)).sort()
+    expect(missing).toEqual([])
+  })
+
+  it('both locales declare the same keys', () => {
+    // Parity is already exact; pinning it means a key added to one locale
+    // cannot silently ship without its counterpart.
+    const onlyDe = [...de].filter((key) => !en.has(key)).sort()
+    const onlyEn = [...en].filter((key) => !de.has(key)).sort()
+    expect({ onlyDe, onlyEn }).toEqual({ onlyDe: [], onlyEn: [] })
+  })
+})

--- a/tests/i18n/message-keys.spec.ts
+++ b/tests/i18n/message-keys.spec.ts
@@ -24,11 +24,13 @@ const SOURCE_DIRS = [
   'composables',
 ]
 
-/** Dotted identifiers passed directly to t/$t/te. */
-const DIRECT_CALL = /\$?\b(?:t|te)\(\s*[`'"]([a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)+)[`'"]/g
+/** Dotted lower-camel identifier, e.g. `article.share_on_x`. */
+const DOTTED = `[a-z][a-zA-Z0-9_]*(?:\\.[a-zA-Z0-9_]+)+`
+
+const DIRECT_CALL = new RegExp(`\\$?\\b(?:t|te)\\(\\s*[\`'"](${DOTTED})[\`'"]`, 'g')
 
 /** `const key = 'a.b'` — captured so a later t(key) can be resolved. */
-const KEY_CONST = /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*[`'"]([a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)+)[`'"]/g
+const KEY_CONST = new RegExp(`\\bconst\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[\`'"](${DOTTED})[\`'"]`, 'g')
 
 /** t(identifier) / te(identifier) — the name is resolved against KEY_CONST. */
 const INDIRECT_CALL = /\$?\b(?:t|te)\(\s*([A-Za-z_$][\w$]*)\s*[,)]/g
@@ -58,7 +60,8 @@ function keysUsedIn(text: string): string[] {
   // fewer.
   const constants = new Map<string, Set<string>>()
   for (const match of text.matchAll(KEY_CONST)) {
-    const [, name, key] = match
+    const name = match[1]
+    const key = match[2]
     if (name === undefined || key === undefined) continue
     const bound = constants.get(name) ?? new Set<string>()
     bound.add(key)
@@ -99,7 +102,12 @@ describe('message keys', () => {
         const text = te(key) ? t(key, { language }) : 'Code in'
       }
     `
-    expect(keysUsedIn(sample).sort()).toEqual(['article.share', 'content.codeIn', 'content.file'])
+    const expected = [
+      'article.share',
+      'content.codeIn',
+      'content.file',
+    ]
+    expect(keysUsedIn(sample).sort()).toEqual(expected)
   })
 
   it('finds keys in use', () => {


### PR DESCRIPTION
Implements part of **PR-15** (`I18N-08`), test-first.

## The defect

`content.file`, `content.codeIn`, `content.codeblock` and `content.permalinkToHeading` existed in **neither locale**. The call sites guard and fall back:

```js
const key = 'content.file'
const text = te(key) ? t(key, { filename }) : `File ${props.filename}`
```

Since the keys never existed, the fallback always won — **every German blog page shipped English ARIA labels** on its code blocks and heading permalinks. Silently, because the guard makes a missing key look handled.

## Two commits, red then green

`497f1c2` adds the test (fails naming all four), `<fix>` adds the keys.

## The test found a bug in itself first

Keys reach `t()` two ways here, and checking only the first is how these stayed missing:

```js
t('article.share')                    // literal argument
const key = 'content.file'            // via a local constant —
te(key) ? t(key, { … }) : 'File …'    // what Prose* does
```

My first version resolved the indirect form with a `Map<name, key>` and reported **two** of the four. Cause: `ProsePre` declares `const key` **three times**, once per block, and the map kept only the last binding. Every binding is now collected. That over-approximates slightly by design — a key that exists is never reported, and erring toward asking for more keys is the safe direction.

A self-test pins both call styles *including the repeated binding*, so a regression in the matching cannot read as "no keys missing". Without it I would have shipped a test that quietly checked half of what it claimed.

## Also pinned

Locale parity, already exact at 276 keys each. A key added to one locale can no longer ship without its counterpart.

## Left alone

The `te()` guards and their fallbacks are now unreachable, as are the `(t as any)` casts that existed because of them. Removing those is a refactor of two components rather than a translation fix, and the test now guarantees the keys exist.

Suite: 20 tests, 5 files. Ratchet unchanged: 357 / 48 / 31.

Refs: `I18N-08`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s