### PR TITLE
fix(a11y): put the visible button text inside its accessible name

### DIFF
--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -33,12 +33,12 @@
       "subtitle": "Wähle deine Plattform und kopiere die Adresse.",
       "java": "Java Edition",
       "bedrock": "Bedrock Edition",
-      "copy_aria": "Serveradresse {address} in die Zwischenablage kopieren",
+      "copy_aria": "Adresse kopieren: {address}",
       "copy": "Kopieren",
       "copy_address": "Adresse kopieren",
       "copied": "Kopiert!",
       "copy_port": "Port kopieren",
-      "copy_port_aria": "Port {port} in die Zwischenablage kopieren",
+      "copy_port_aria": "Port kopieren: {port}",
       "port_label": "Port",
       "clipboard_note": "Dein Browser unterstützt das Kopieren in die Zwischenablage nicht. Bitte kopiere die Adresse manuell."
     }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -33,12 +33,12 @@
       "subtitle": "Choose your platform and copy the address.",
       "java": "Java Edition",
       "bedrock": "Bedrock Edition",
-      "copy_aria": "Copy server address {address} to clipboard",
+      "copy_aria": "Copy address: {address}",
       "copy": "Copy",
       "copy_address": "Copy address",
       "copied": "Copied!",
       "copy_port": "Copy port",
-      "copy_port_aria": "Copy port {port} to clipboard",
+      "copy_port_aria": "Copy port: {port}",
       "port_label": "Port",
       "clipboard_note": "Your browser does not support copying to the clipboard. Please copy the address manually."
     }

--- a/tests/i18n/label-in-name.spec.ts
+++ b/tests/i18n/label-in-name.spec.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * WCAG 2.5.3 "Label in Name" (Level A): when a control has visible text, its
+ * accessible name must contain that text. Speech-input users say what they
+ * read — "click copy address" — and the tool matches the spoken words against
+ * the accessible name. If the visible label is not in there, the control
+ * cannot be operated by voice at all.
+ *
+ * The failure is invisible in review because both strings look fine on their
+ * own. The server address card said "Adresse kopieren" on the button and
+ * "Serveradresse {address} in die Zwischenablage kopieren" in aria-label: the
+ * same words, rearranged, which does not satisfy the criterion. The success
+ * criterion wants the visible label as a contiguous substring.
+ *
+ * These pairs are declared rather than discovered: matching a `label-key` prop
+ * to an `aria-label` expression across component boundaries needs a real
+ * parser, and a wrong guess here would either pass silently or block unrelated
+ * work. Add a pair when you add a control that carries both.
+ */
+
+/** [visible label key, accessible name key] — both must exist in each locale. */
+const LABEL_PAIRS: [string, string][] = [
+  ['server.connect.copy_address', 'server.connect.copy_aria'],
+  ['server.connect.copy_port', 'server.connect.copy_port_aria'],
+]
+
+const LOCALES = [
+  'de',
+  'en',
+]
+
+function messages(locale: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(repoRoot, `i18n/locales/${locale}.json`), 'utf8'))
+}
+
+function lookup(tree: Record<string, unknown>, dotted: string): string | undefined {
+  let node: unknown = tree
+  for (const segment of dotted.split('.')) {
+    if (typeof node !== 'object' || node === null) return undefined
+    node = (node as Record<string, unknown>)[segment]
+  }
+  return typeof node === 'string' ? node : undefined
+}
+
+/** Interpolation placeholders stand in for runtime values; drop them. */
+function withoutPlaceholders(message: string): string {
+  return message.replace(/\{\w+\}/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+describe('WCAG 2.5.3 label in name', () => {
+  it('has pairs to check', () => {
+    expect(LABEL_PAIRS.length).toBeGreaterThan(0)
+  })
+
+  for (const locale of LOCALES) {
+    describe(locale, () => {
+      const tree = messages(locale)
+
+      for (const [visibleKey, ariaKey] of LABEL_PAIRS) {
+        it(`${visibleKey} appears in ${ariaKey}`, () => {
+          const visible = lookup(tree, visibleKey)
+          const accessible = lookup(tree, ariaKey)
+          expect(visible, `${visibleKey} missing in ${locale}`).toBeDefined()
+          expect(accessible, `${ariaKey} missing in ${locale}`).toBeDefined()
+
+          // Case-insensitive: assistive tech matches without regard to case,
+          // and the criterion is about the words, not their capitalisation.
+          const haystack = withoutPlaceholders(accessible as string).toLowerCase()
+          const needle = withoutPlaceholders(visible as string).toLowerCase()
+          expect(haystack).toContain(needle)
+        })
+      }
+    })
+  }
+})

--- a/tests/i18n/label-in-name.spec.ts
+++ b/tests/i18n/label-in-name.spec.ts
@@ -24,13 +24,11 @@ import { repoRoot } from '../helpers/sources'
 
 /** [visible label key, accessible name key] — both must exist in each locale. */
 const LABEL_PAIRS: [string, string][] = [
-  ['server.connect.copy_address', 'server.connect.copy_aria'],
-  ['server.connect.copy_port', 'server.connect.copy_port_aria'],
+  ['server.connect.copy_address', 'server.connect.copy_aria'], ['server.connect.copy_port', 'server.connect.copy_port_aria'],
 ]
 
 const LOCALES = [
-  'de',
-  'en',
+  'de', 'en',
 ]
 
 function messages(locale: string): Record<string, unknown> {


### PR DESCRIPTION
Implements **PR-14**'s first item (`A11Y-03`), test-first. **WCAG 2.5.3 "Label in Name" — Level A.**

## The defect

The copy buttons on the home page:

| | visible text | `aria-label` |
|---|---|---|
| Java address | „Adresse kopieren" | „Server**adresse** {address} in die Zwischenablage **kopieren**" |
| Port | „Port kopieren" | „**Port** {port} in die Zwischenablage **kopieren**" |

Same words, rearranged. **Speech-input users say what they see** — "klick Adresse kopieren". The tool matches the spoken words against the accessible name, finds no contiguous match, and the button cannot be operated by voice at all.

Three of the four locale strings failed. English `"Copy port to clipboard"` happened to pass, which is exactly why this needs a test rather than a careful reading.

## The fix

```
de  "Adresse kopieren: {address}"      en  "Copy address: {address}"
de  "Port kopieren: {port}"            en  "Copy port: {port}"
```

Each starts with the visible label and keeps the value that gave the old phrasing its context. Nothing changes visually — only the accessible name.

## The test

Compares the visible-label key against the accessible-name key per locale, stripping interpolation placeholders (they stand in for runtime values) and matching case-insensitively (assistive tech matches words, not capitalisation).

**The pairs are declared, not discovered.** Matching a `label-key` prop to an `aria-label` expression across component boundaries needs a real parser; a wrong guess would either pass silently or block unrelated work. The docblock says to add a pair when adding a control that carries both — a deliberate trade of coverage for reliability.

## Why this failure mode needs a test at all

Both strings read perfectly well on their own. Nothing in review, lint or the type checker looks at the *relationship* between them, and the button works fine with a mouse, a keyboard and a screen reader. It only fails for voice control.

Suite: 25 tests, 6 files. Ratchet unchanged: 357 / 48 / 31.

Refs: `A11Y-03`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s