### PR TITLE
fix(content): give releaseDate a column and stop the page overriding its own title

### DIFF
--- a/composables/useArticleSeo.ts
+++ b/composables/useArticleSeo.ts
@@ -89,19 +89,30 @@ export function useArticleSeo(
   const isoDate = (value: Date | string | undefined) =>
     value ? new Date(value).toISOString() : undefined
 
+  // The title as it should reach <title> and the social cards: a per-article
+  // `seo.title` override wins, otherwise the A/B-flagged title above.
+  //
+  // Exported because pages/blog/[...slug].vue re-asserts the title through its
+  // own useHead — which runs after this and therefore wins. It used to pass
+  // the raw `blog.title`, discarding both the override and the A/B variant.
+  const metaTitle = computed(() => {
+    const seo = ((blog.value as { seo?: BlogSeoFrontmatter } | null)?.seo) || {}
+    return seo.title || title.value
+  })
+
   // Document-level meta + OG/Twitter cards.
   useSeoMeta(() => {
     const seo = ((blog.value as { seo?: BlogSeoFrontmatter } | null)?.seo) || {}
-    const metaTitle = seo.title || title.value
+    const resolvedTitle = metaTitle.value
     const metaDescription = seo.description
       || blog.value?.description
       || extractPlainText((blog.value as { excerpt?: unknown } | null)?.excerpt)
       || ''
     const headerAlt = blog.value?.headerImageAlt || blog.value?.title || ''
     return {
-      title: metaTitle,
-      ogTitle: seo.ogTitle || metaTitle,
-      twitterTitle: seo.twitterTitle || metaTitle,
+      title: resolvedTitle,
+      ogTitle: seo.ogTitle || resolvedTitle,
+      twitterTitle: seo.twitterTitle || resolvedTitle,
       description: metaDescription,
       ogDescription: seo.ogDescription || metaDescription,
       ogImage: previewSocial.value,
@@ -163,5 +174,5 @@ export function useArticleSeo(
     description: blog.value?.description || ''
   })
 
-  return { title, canonicalUrl, previewSocial }
+  return { title, metaTitle, canonicalUrl, previewSocial }
 }

--- a/composables/useBlogContent.ts
+++ b/composables/useBlogContent.ts
@@ -9,9 +9,11 @@ import type {
 } from '~/types/blog'
 
 const normalizeReleaseDate = (entry: BlogArticle): Date | null => {
+  // `releaseDate` and `pubDate` are schema columns now, so both arrive as
+  // the coerced value @nuxt/content stores rather than a hand-typed union.
   const raw = entry.releaseDate ?? entry.pubDate
   if (!raw) return null
-  const parsed = raw instanceof Date ? raw : new Date(raw)
+  const parsed = new Date(raw)
   return Number.isNaN(parsed.getTime()) ? null : parsed
 }
 

--- a/content.config.ts
+++ b/content.config.ts
@@ -28,7 +28,15 @@ const blogSchema = withI18nMeta(z.object({
     excerpt: z.object({
       type: z.string(),
       children: z.any()
-    })
+    }),
+    // Publication gate: useBlogContent hides an article until this date and
+    // falls back to pubDate when unset. Without the column the field was
+    // always undefined, so the gate silently never applied.
+    //
+    // `seo` and `head` are deliberately NOT declared here: @nuxt/content
+    // provides both as built-in columns on every page collection. Redeclaring
+    // `seo` would replace that built-in shape with a narrower one.
+    releaseDate: z.coerce.date().optional()
   }))
 
 const carouselSchema = z.object({

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -20,7 +20,7 @@ const LazySocialMediaShare = defineAsyncComponent(() => import('~/components/fea
 // Canonical + hreflang are emitted app-wide by @nuxtjs/i18n
 // (layouts/default.vue), driven by the translated slugs useBlogArticle
 // publishes via useSetI18nParams.
-const { title } = useArticleSeo(blog, authors)
+const { title, metaTitle } = useArticleSeo(blog, authors)
 
 // Absolute URL for the share buttons. Built here rather than inline in the
 // template: `locale` is a ref and a template auto-unwraps it, so the
@@ -43,14 +43,18 @@ const shareUrl = computed(() => {
 useHead(() => {
   const b = blog.value as BlogArticle | null
   if (!b) return {}
+  // Uses metaTitle, not b.title. This block runs after useArticleSeo and wins,
+  // so passing the raw title discarded both the per-article `seo.title`
+  // override and the A/B-flagged `alternativeTitle` that composable resolves.
+  const resolved = metaTitle.value
   const meta = [
     { name: 'description', content: b.description },
-    { property: 'og:title', content: b.title },
+    { property: 'og:title', content: resolved },
     { property: 'og:description', content: b.description },
-    { name: 'twitter:title', content: b.title },
+    { name: 'twitter:title', content: resolved },
     { name: 'twitter:description', content: b.description }
   ].filter((m) => Boolean(m.content))
-  return { title: b.title, meta, ...(b.head || {}) }
+  return { title: resolved, meta }
 })
 </script>
 

--- a/tests/content/schema-columns.spec.ts
+++ b/tests/content/schema-columns.spec.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * In @nuxt/content v3 the zod schema is a DDL: each declared field becomes a
+ * column. A frontmatter key the schema does not declare is not rejected and
+ * not type-checked — it lands in the catch-all `meta` JSON blob, so reading it
+ * yields `undefined` and filtering on it fails with "no such column".
+ *
+ * types/blog.ts widens the generated collection type with hand-written fields.
+ * That compiles and type-checks whether or not the schema declares them, which
+ * is how three of them ended up always undefined at runtime:
+ *
+ *   releaseDate  read by useBlogContent for release gating, which therefore
+ *                always fell through to pubDate
+ *   seo          read by useArticleSeo to override the meta title, so the
+ *                override never applied
+ *   head         spread into useHead on the article page, always empty
+ *
+ * The type is the right place to check: it is where a field gets promised to
+ * the rest of the codebase.
+ */
+
+/**
+ * Fields legitimately absent from the schema because they are attached at
+ * runtime rather than parsed from frontmatter.
+ */
+const RUNTIME_ONLY = new Set([
+  // useBlogContent resolves author slugs against the authors collection and
+  // attaches the profiles; never present in a markdown file.
+  'authors',
+])
+
+function blogTypeFields(): string[] {
+  const text = readFileSync(join(repoRoot, 'types/blog.ts'), 'utf8')
+  const block = /export type BlogArticle =[\s\S]*?\)\s*&\s*\{([\s\S]*?)\n\}/.exec(text)?.[1]
+  if (block === undefined) throw new Error('BlogArticle shape not found in types/blog.ts')
+  return [...block.matchAll(/^\s{2}(\w+)\??:/gm)]
+    .map((match) => match[1])
+    .filter((name): name is string => name !== undefined)
+}
+
+function blogSchemaFields(): string[] {
+  const text = readFileSync(join(repoRoot, 'content.config.ts'), 'utf8')
+  const block = /const blogSchema = withI18nMeta\(z\.object\(\{([\s\S]*?)\n {2}\}\)\)/.exec(text)?.[1]
+  if (block === undefined) throw new Error('blogSchema not found in content.config.ts')
+  const own = [...block.matchAll(/^\s{4}(\w+):/gm)]
+    .map((match) => match[1])
+    .filter((name): name is string => name !== undefined)
+  // withI18nMeta adds these to every collection it wraps.
+  return own.concat([
+    'translationKey',
+    'canonical',
+    'alternates',
+  ])
+}
+
+describe('blog frontmatter columns', () => {
+  it('parses both declarations', () => {
+    // A broken regex here would silently turn the check below into a no-op.
+    expect(blogTypeFields().length).toBeGreaterThan(3)
+    expect(blogSchemaFields().length).toBeGreaterThan(8)
+  })
+
+  it('every field BlogArticle promises exists as a column', () => {
+    const columns = new Set(blogSchemaFields())
+    const missing = blogTypeFields()
+      .filter((field) => !RUNTIME_ONLY.has(field))
+      .filter((field) => !columns.has(field))
+      .sort()
+    expect(missing).toEqual([])
+  })
+})

--- a/tests/content/schema-columns.spec.ts
+++ b/tests/content/schema-columns.spec.ts
@@ -24,13 +24,21 @@ import { repoRoot } from '../helpers/sources'
  */
 
 /**
- * Fields legitimately absent from the schema because they are attached at
- * runtime rather than parsed from frontmatter.
+ * Fields legitimately absent from the collection's own schema.
+ *
+ * Verified against the built SQL dump rather than assumed — `seo` and `head`
+ * look exactly like the broken cases in review, and an earlier revision of
+ * this change "fixed" them by declaring `seo` and deleting `head` from the
+ * type. Both were wrong: the dump shows the columns present on plain `main`.
  */
-const RUNTIME_ONLY = new Set([
-  // useBlogContent resolves author slugs against the authors collection and
-  // attaches the profiles; never present in a markdown file.
+const NOT_FROM_SCHEMA = new Set([
+  // Attached at runtime: useBlogContent resolves author slugs against the
+  // authors collection, so this is never in a markdown file.
   'authors',
+  // Built into every @nuxt/content page collection. Declaring `seo` here
+  // would replace the built-in shape with a narrower one.
+  'seo',
+  'head',
 ])
 
 function blogTypeFields(): string[] {
@@ -42,9 +50,11 @@ function blogTypeFields(): string[] {
     .filter((name): name is string => name !== undefined)
 }
 
+const BLOG_SCHEMA = /const blogSchema = withI18nMeta\(z\.object\(\{([\s\S]*?)\n {2}\}\)\)/
+
 function blogSchemaFields(): string[] {
   const text = readFileSync(join(repoRoot, 'content.config.ts'), 'utf8')
-  const block = /const blogSchema = withI18nMeta\(z\.object\(\{([\s\S]*?)\n {2}\}\)\)/.exec(text)?.[1]
+  const block = BLOG_SCHEMA.exec(text)?.[1]
   if (block === undefined) throw new Error('blogSchema not found in content.config.ts')
   const own = [...block.matchAll(/^\s{4}(\w+):/gm)]
     .map((match) => match[1])
@@ -67,7 +77,7 @@ describe('blog frontmatter columns', () => {
   it('every field BlogArticle promises exists as a column', () => {
     const columns = new Set(blogSchemaFields())
     const missing = blogTypeFields()
-      .filter((field) => !RUNTIME_ONLY.has(field))
+      .filter((field) => !NOT_FROM_SCHEMA.has(field))
       .filter((field) => !columns.has(field))
       .sort()
     expect(missing).toEqual([])

--- a/types/blog.ts
+++ b/types/blog.ts
@@ -43,7 +43,6 @@ export type BlogArticle = (
   author?: string | string[]
   authors?: BlogAuthorProfile[]
   teamMembers?: string[]
-  releaseDate?: string | Date
   canonical?: string
   alternates?: BlogAlternateHeader[]
   seo?: BlogSEO


### PR DESCRIPTION
Implements `CNT-04` and `ARCH-03`, test-first — and **disproves two findings** along the way.

## What the test found

In `@nuxt/content` v3 the zod schema is a DDL: an undeclared field is not a column, so reading it yields `undefined` and filtering on it fails. `types/blog.ts` widens the generated type with hand-written fields, which compiles either way. The test compares the two and named three:

| field | verdict |
|---|---|
| `releaseDate` | **real** — never a column, gate always fell through to `pubDate` |
| `seo` | **built-in column**, present all along |
| `head` | **built-in column**, present all along |

## The two real fixes

**`releaseDate` declared.** Verified in the built SQL dump, which gains the column.

Removing the hand-written `releaseDate?: string | Date` is part of the same fix, not tidying: once the field is generated, the intersection of both declarations collapses to `string`, and the `instanceof Date` narrowing in `normalizeReleaseDate` becomes a type error. The ratchet caught exactly that.

**The page stopped overriding its own title.** `pages/blog/[...slug].vue` re-asserted `title`, `og:title` and `twitter:title` through its own `useHead`. That block runs *after* `useArticleSeo` and therefore wins — and it passed the raw `blog.title`, discarding **both** the per-article `seo.title` override **and** the A/B-flagged `alternativeTitle`. `useArticleSeo` now exports the resolved `metaTitle`; the page uses it.

The block itself stays. Its comment explains it exists to beat a slug-cased ASCII fallback, and that reason is unchanged — deleting it would have brought back the problem it was written for.

## Two findings disproved

`seo` and `head` were reported as declared-but-never-a-column. **Both are built-in `@nuxt/content` page-collection columns**, present on plain `main`.

An earlier revision of this branch "fixed" them: declared `seo` in the schema — which would have **replaced the built-in shape with a narrower one** — and deleted `head` from the type. I caught it only by building `main` and diffing the SQL dump, which the content skill requires for schema changes. Both reverted; the schema now carries a comment saying why neither belongs there, and the test's exemption list records the same.

The `...(b.head || {})` spread is gone regardless: it let content inject arbitrary head entries, and no article uses it.

## Verification

```
SQL dump    releaseDate ✓  seo ✓  head ✓   (all three columns present)
Suite       27 tests, 7 files
Ratchet     357 / 48 / 31 — no regression
Build       green
```

Refs: `CNT-04`, `ARCH-03`. Disproves the `seo`/`head` half of `TS-03`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s