### PR TITLE
fix(content): describe the carousel slides the schema actually receives

### DIFF
--- a/composables/useHomeContent.ts
+++ b/composables/useHomeContent.ts
@@ -62,7 +62,7 @@ export function useHomeContent() {
   )
 
   const slides = computed<HomeCarouselSlide[]>(() => {
-    const base = (homeCarousel.value?.slides as HomeCarouselSlide[] | undefined) ?? []
+    const base = homeCarousel.value?.slides ?? []
     const featured = (featuredPois.value || []).filter((p) => p.featured)
     if (!featured.length) return base
     const ordered = [...featured].sort((a, b) => {

--- a/content.config.ts
+++ b/content.config.ts
@@ -39,13 +39,74 @@ const blogSchema = withI18nMeta(z.object({
     releaseDate: z.coerce.date().optional()
   }))
 
+// Mirrors the discriminated union in types/carousel.ts. The previous shape
+// here was a flat `{ title, image }`, which described none of the slides that
+// exist: @nuxt/content derives columns from this rather than validating
+// against it, so `slides` landed in one JSON column regardless and only the
+// generated type was wrong — which useHomeContent then cast away.
 const carouselSchema = z.object({
   key: z.string().optional(),
   slides: z
-    .array(z.object({
+    .array(z.union([
+      z.object({
+        type: z.literal('image'),
+        src: z.string(),
+        alt: z.string(),
+        note: z.string().optional()
+      }),
+      z.object({
+        type: z.literal('blog'),
         title: z.string(),
-        image: z.string()
-      }))
+        href: z.string(),
+        excerpt: z.string().optional(),
+        image: z.string().optional(),
+        alt: z.string().optional(),
+        author: z.string().optional(),
+        date: z.union([z.string(), z.coerce.date()]).optional(),
+        tag: z.string().optional()
+      }),
+      z.object({
+        type: z.literal('news'),
+        title: z.string(),
+        href: z.string().optional(),
+        summary: z.string().optional(),
+        image: z.string().optional(),
+        alt: z.string().optional(),
+        date: z.union([z.string(), z.coerce.date()]).optional(),
+        tag: z.string().optional()
+      }),
+      z.object({
+        type: z.literal('poi'),
+        title: z.string(),
+        href: z.string(),
+        caption: z.string().optional(),
+        image: z.string().optional(),
+        alt: z.string().optional(),
+        status: z.enum([
+          'planning',
+          'in-progress',
+          'paused',
+          'completed'
+        ]).optional(),
+        progress: z.number().optional(),
+        category: z.enum([
+          'team',
+          'community',
+          'collab'
+        ]).optional()
+      }),
+      z.object({
+        type: z.literal('event'),
+        title: z.string(),
+        dateStart: z.union([z.string(), z.coerce.date()]),
+        dateEnd: z.union([z.string(), z.coerce.date()]).optional(),
+        location: z.string().optional(),
+        href: z.string().optional(),
+        image: z.string().optional(),
+        alt: z.string().optional(),
+        note: z.string().optional()
+      })
+    ]))
     .default([])
 })
 

--- a/tests/content/carousel-schema.spec.ts
+++ b/tests/content/carousel-schema.spec.ts
@@ -20,10 +20,7 @@ import { repoRoot } from '../helpers/sources'
  * actual content files, which is the thing that would have caught it.
  */
 
-const LOCALES = [
-  'de',
-  'en',
-]
+const LOCALES = ['de', 'en']
 
 interface Slide {
   type?: string

--- a/tests/content/carousel-schema.spec.ts
+++ b/tests/content/carousel-schema.spec.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * The carousel schema in content.config.ts described `{ title, image }`.
+ * Every slide in the content files is one of a discriminated union keyed on
+ * `type` — `{ type: 'image', src, alt, note }` or `{ type: 'blog', title,
+ * href, … }`. Not a single slide matched.
+ *
+ * @nuxt/content v3 does not validate against the schema; it uses it to derive
+ * columns. `slides` is an array, so it lands in one JSON column whatever its
+ * contents, and the mismatch never surfaced at runtime — only in the generated
+ * type, which claimed `{ title, image }[]`. useHomeContent papered over that
+ * with `as HomeCarouselSlide[]`, and the cast is the only reason the code
+ * compiles.
+ *
+ * So the schema has to describe reality. This test compares it against the
+ * actual content files, which is the thing that would have caught it.
+ */
+
+const LOCALES = [
+  'de',
+  'en',
+]
+
+interface Slide {
+  type?: string
+  [key: string]: unknown
+}
+
+function slidesFrom(locale: string): Slide[] {
+  const file = join(repoRoot, `content/carousel/${locale}/home.json`)
+  const parsed = JSON.parse(readFileSync(file, 'utf8')) as { slides?: Slide[] }
+  return parsed.slides ?? []
+}
+
+/** Field names the schema declares for each slide variant. */
+function schemaVariants(): Map<string, Set<string>> {
+  const text = readFileSync(join(repoRoot, 'content.config.ts'), 'utf8')
+  const block = /const carouselSchema = z\.object\(\{([\s\S]*?)\n\}\)/.exec(text)?.[1]
+  if (block === undefined) throw new Error('carouselSchema not found')
+  const variants = new Map<string, Set<string>>()
+  // Each variant is a z.object({...}) carrying a z.literal('<type>').
+  for (const match of block.matchAll(/z\.object\(\{([\s\S]*?)\}\)/g)) {
+    const body = match[1] ?? ''
+    const type = /z\.literal\('([a-z]+)'\)/.exec(body)?.[1]
+    if (type === undefined) continue
+    const fields = [...body.matchAll(/^\s*(\w+):/gm)]
+      .map((field) => field[1])
+      .filter((name): name is string => name !== undefined)
+    variants.set(type, new Set(fields))
+  }
+  return variants
+}
+
+describe('carousel content', () => {
+  it('every slide declares a type', () => {
+    // The union is keyed on `type`; a slide without one cannot be validated
+    // or rendered by the matching component.
+    for (const locale of LOCALES) {
+      const untyped = slidesFrom(locale).filter((slide) => slide.type === undefined)
+      expect(untyped, `${locale} has slides without a type`).toEqual([])
+    }
+  })
+
+  it('finds slides to check', () => {
+    expect(LOCALES.flatMap(slidesFrom).length).toBeGreaterThan(3)
+  })
+})
+
+describe('carousel schema', () => {
+  const variants = schemaVariants()
+
+  it('describes the slide variants as a discriminated union', () => {
+    // A single flat object cannot describe both an image slide and a blog
+    // slide, which is how the original `{ title, image }` shape went wrong.
+    expect(variants.size).toBeGreaterThan(1)
+  })
+
+  it('covers every type present in the content', () => {
+    const used = new Set(LOCALES.flatMap(slidesFrom).map((slide) => slide.type))
+    const uncovered = [...used].filter((type) => type !== undefined && !variants.has(type)).sort()
+    expect(uncovered).toEqual([])
+  })
+
+  it('declares every field the content actually uses', () => {
+    const missing: string[] = []
+    for (const locale of LOCALES) {
+      for (const slide of slidesFrom(locale)) {
+        const declared = variants.get(slide.type ?? '')
+        if (declared === undefined) continue
+        for (const field of Object.keys(slide)) {
+          if (!declared.has(field)) missing.push(`${locale} ${slide.type}.${field}`)
+        }
+      }
+    }
+    expect([...new Set(missing)].sort()).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `CNT-02` and `TS-04`, test-first.

## The mismatch

`carouselSchema` declared `{ title, image }`. Every slide in the content files belongs to a discriminated union keyed on `type`:

```json
{ "type": "image", "src": "…", "alt": "…", "note": "…" }
{ "type": "blog",  "title": "…", "href": "…", "excerpt": "…", "author": "…" }
```

**Not one slide matched the declared shape.**

## Why it never broke

`@nuxt/content` v3 derives columns from the schema rather than validating against it. `slides` is an array, so it landed in a single JSON column whatever it contained — the data was always fine.

Only the *generated type* was wrong, claiming `{ title, image }[]`. `useHomeContent` absorbed that with `as HomeCarouselSlide[]` — a cast whose sole purpose was hiding the mismatch. The compiler had been told to stop looking at the one place where it would have noticed.

## The fix

The schema is now the union from `types/carousel.ts` — image, blog, news, poi and event, each with the fields its component reads.

**With the generated type correct, the cast is gone.** `homeCarousel.value?.slides` assigns to `HomeCarouselSlide[]` on its own now. That is the real gain: the type checker sees the actual shape, so a slide variant gaining a field, or a component reading one that does not exist, becomes a compile error instead of nothing at all.

## The test

Compares the schema against the **real content files** rather than against a second declaration — that comparison is what would have caught the original defect. Three assertions:

- every type present in the content is declared
- every field a slide actually carries exists on its variant
- the schema is a union at all, since a single flat object cannot describe both an image and a blog slide, which is exactly how it went wrong

Plus one on the content side: every slide declares a `type`, because the union is keyed on it.

Suite: 30 tests, 7 files. Ratchet unchanged: 357 / 48 / 31.

Refs: `CNT-02`, `TS-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s