### PR TITLE
fix(security): sandbox the BlueMap embeds

### DIFF
--- a/components/features/community-poi/CommunityPoiBluemap.vue
+++ b/components/features/community-poi/CommunityPoiBluemap.vue
@@ -99,12 +99,15 @@ const embedNoteClass = [
          fetch until the section is in view, which keeps initial page
          weight reasonable. -->
     <div class="overflow-hidden rounded-md border border-neutral-200 dark:border-neutral-800">
+      <!-- Same sandbox as pages/bluemap.vue; see the comment there for why
+           allow-scripts and allow-same-origin are both needed. -->
       <iframe
         :src="deepLink"
         :title="t('community_poi.bluemap.iframe_title', { title: props.title })"
         class="block aspect-[16/9] w-full"
         loading="lazy"
         allow="fullscreen"
+        sandbox="allow-scripts allow-same-origin allow-popups"
         referrerpolicy="no-referrer"
       />
       <p :class="embedNoteClass">

--- a/pages/bluemap.vue
+++ b/pages/bluemap.vue
@@ -32,12 +32,25 @@ useBreadcrumbs(() => [
         <h1 class="text-2xl font-semibold text-[var(--color-text)]">BlueMap</h1>
       </div>
       <div class="rounded-xl overflow-hidden border border-[var(--color-border)] bg-[var(--color-surface)]">
+        <!--
+          The embed is third-party by origin and its URL comes from runtime
+          config, so this page cannot assume the content stays what it is.
+
+          allow-scripts and allow-same-origin are both required — it is a WebGL
+          map keeping state in its own storage. Together they do let a
+          same-origin frame drop its own sandbox; that does not apply here
+          because the embed is cross-origin. What stays withheld is the part
+          that matters: top-level navigation, so the frame cannot replace this
+          tab, plus modals, downloads and pointer lock.
+        -->
         <iframe
           :src="bluemapUrl"
           title="BlueMap"
           class="w-full h-[75vh] sm:h-[80vh]"
           loading="lazy"
           allow="fullscreen"
+          sandbox="allow-scripts allow-same-origin allow-popups"
+          referrerpolicy="strict-origin-when-cross-origin"
         />
       </div>
     </div>

--- a/tests/security/iframe-sandbox.spec.ts
+++ b/tests/security/iframe-sandbox.spec.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * An iframe without `sandbox` runs the embedded document with every capability
+ * the browser offers. The one that matters here is top-level navigation: the
+ * embedded page can replace the hosting tab, so a compromised or
+ * misconfigured embed becomes a redirect off the site. `sandbox` also
+ * withholds modals, downloads and pointer lock, none of which a map needs.
+ *
+ * The BlueMap embed is third-party by origin (bluemap.onelitefeather.dev) and
+ * its URL comes from runtime config, so the page hosting it cannot assume the
+ * content stays what it is today.
+ *
+ * `allow-scripts allow-same-origin` together do let a same-origin frame remove
+ * its own sandbox — worth knowing, and not a problem here: the embed is
+ * cross-origin, and both flags are required for a WebGL map that keeps state
+ * in its own storage. What the attribute still withholds is the list above.
+ */
+
+const SOURCE_DIRS = [
+  'components',
+  'pages',
+  'layouts',
+]
+
+const IFRAME = /<iframe\b[^>]*>/gs
+
+function iframes(): { file: string, line: number, element: string }[] {
+  const found: { file: string, line: number, element: string }[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue'])) {
+    const text = readFileSync(file, 'utf8')
+    for (const match of text.matchAll(IFRAME)) {
+      found.push({
+        file: relativeToRepo(file),
+        line: text.slice(0, match.index).split('\n').length,
+        element: match[0],
+      })
+    }
+  }
+  return found
+}
+
+describe('embedded frames', () => {
+  it('finds iframes to check', () => {
+    expect(iframes().length).toBeGreaterThan(0)
+  })
+
+  it('all carry a sandbox attribute', () => {
+    const missing = iframes()
+      .filter((frame) => !/\bsandbox=/.test(frame.element))
+      .map((frame) => `${frame.file}:${frame.line}`)
+    expect(missing).toEqual([])
+  })
+
+  it('none grant top-level navigation', () => {
+    // The capability that turns an embed into a redirect off the site.
+    const granted = iframes()
+      .filter((frame) => /allow-top-navigation/.test(frame.element))
+      .map((frame) => `${frame.file}:${frame.line}`)
+    expect(granted).toEqual([])
+  })
+
+  it('all set a referrer policy', () => {
+    // Without one the embedded origin receives the full hosting URL.
+    const missing = iframes()
+      .filter((frame) => !/\breferrerpolicy=/.test(frame.element))
+      .map((frame) => `${frame.file}:${frame.line}`)
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `SEC-08`, test-first. Small.

## The gap

Neither iframe carried `sandbox`, so both ran the embedded document with every capability the browser grants. The one that matters: **top-level navigation** — the frame can replace the hosting tab, turning a compromised or reconfigured embed into a redirect off the site.

Both embeds are third-party by origin, and one takes its URL from runtime config. Neither page can assume the content stays what it is today.

```
sandbox="allow-scripts allow-same-origin allow-popups"
```

`allow-scripts` and `allow-same-origin` are both required — it is a WebGL map keeping state in its own storage. Those two together **do** let a same-origin frame drop its own sandbox; that does not apply here, the embeds are cross-origin. What stays withheld is top-level navigation, modals, downloads and pointer lock.

`pages/bluemap.vue` also had no referrer policy, so the embedded origin received the full hosting URL. Now `strict-origin-when-cross-origin`. The POI embed already sent `no-referrer` and keeps it.

## The test found a second iframe

`components/features/community-poi/CommunityPoiBluemap.vue` — added with the POI feature, **not part of the original finding**. A grep of the page named in the report would have missed it entirely, and the fix would have been half-done.

Four assertions: every iframe has a sandbox, none grants `allow-top-navigation`, every one sets a referrer policy, and at least one iframe exists so the suite cannot pass vacuously.

Suite: 31 tests, 8 files. Ratchet unchanged: 357 / 48 / 31.

Refs: `SEC-08`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s