### PR TITLE
fix(carousel): drop the dead aura code and stop leaking a media-query listener

### DIFF
--- a/components/features/home/carousel/Carousel.vue
+++ b/components/features/home/carousel/Carousel.vue
@@ -32,21 +32,11 @@ const props = withDefaults(defineProps<{
 const current = ref(0)
 const timer = ref<ReturnType<typeof setInterval> | null>(null)
 const isHovering = ref(false)
-const prefersReducedMotion = ref(false)
-
-// Aura color handling (outside glow)
-const auraColors = ref<Record<number, string>>({})
-const defaultAura = 'rgb(39, 169, 225)' // fallback: brand secondary-ish
-const activeAuraColor = computed(() => auraColors.value[current.value] || defaultAura)
-const outerAuraStyle = computed(() => {
-  const base = activeAuraColor.value
-  // Outside glow: larger radius, blurred, extends outside container
-  return {
-    background: `radial-gradient(60% 45% at 50% 50%, ${withAlpha(base, 0.32)} 0%, ${withAlpha(base, 0.16)} 40%, transparent 75%)`,
-    filter: 'blur(18px)',
-    opacity: '1'
-  }
-})
+// useMediaQuery rather than a hand-rolled matchMedia listener: it unregisters
+// with the effect scope. The previous version subscribed to the MediaQueryList
+// and never unsubscribed, so every visit to this page left another live
+// listener holding the whole component scope.
+const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
 
 // Normalization: Legacy → typed slides
 const normalizedSlides = computed<NormalizedSlide[]>(() => normalizeSlides(props.slides))
@@ -217,21 +207,6 @@ const componentFor = (slide: NormalizedSlide) => {
 }
 
 
-// Setup reduced motion preference (client only)
-if (import.meta.client) {
-  try {
-    const m = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const set = () => { prefersReducedMotion.value = !!m.matches }
-    set()
-    m.addEventListener?.('change', set)
-  } catch {}
-}
-
-function withAlpha(rgb: string, a: number) {
-  const m = rgb.match(/rgb\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)\)/)
-  if (!m) return rgb
-  return `rgba(${m[1]}, ${m[2]}, ${m[3]}, ${a})`
-}
 </script>
 
 <template>

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 357,
+  "eslintErrors": 356,
   "eslintWarnings": 48,
   "typeErrors": 31
 }

--- a/tests/architecture/event-listeners.spec.ts
+++ b/tests/architecture/event-listeners.spec.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * A listener registered in a component's setup outlives the component unless
+ * something removes it. On a client-side navigation the component unmounts,
+ * the listener stays subscribed, and its closure keeps the whole component
+ * scope — refs, computeds, props — reachable. Return to the page and a second
+ * listener joins the first.
+ *
+ * @vueuse/core is already a dependency and its composables unregister on
+ * scope disposal, so `useMediaQuery`, `useEventListener` and friends are the
+ * answer here rather than a hand-written onUnmounted.
+ *
+ * Scope note: this only looks at .vue files, and only for the listener APIs
+ * that attach to a long-lived target. A listener on an element inside the
+ * component's own template dies with the element; one on `window`,
+ * `document` or a MediaQueryList does not.
+ */
+
+const SOURCE_DIRS = [
+  'components',
+  'pages',
+  'layouts',
+]
+
+/** Registrations on a target that outlives the component. */
+const LONG_LIVED_TARGET = /\b(?:window|document|m|mql|mediaQuery)(?:\?\.|\.)addEventListener(?:\?\.)?\(/g
+const ANY_REMOVE = /removeEventListener/
+/** @vueuse composables tear down with the effect scope. */
+const VUEUSE_MANAGED = /\buse(?:EventListener|MediaQuery|WindowSize|Scroll|Intersection\w*)\s*\(/
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue'])) {
+    const text = readFileSync(file, 'utf8')
+    const registrations = [...text.matchAll(LONG_LIVED_TARGET)]
+    if (registrations.length === 0) continue
+    if (ANY_REMOVE.test(text)) continue
+    if (VUEUSE_MANAGED.test(text)) continue
+    found.push(`${relativeToRepo(file)} (${registrations.length})`)
+  }
+  return found
+}
+
+describe('event listeners', () => {
+  it('distinguishes managed from unmanaged registrations', () => {
+    // Without this the check could pass by matching nothing at all.
+    expect(LONG_LIVED_TARGET.test('window.addEventListener("resize", fn)')).toBe(true)
+    LONG_LIVED_TARGET.lastIndex = 0
+    // Optional-call form: `?.` is two characters, and missing that is why an
+    // earlier version of this pattern reported a clean tree.
+    expect(LONG_LIVED_TARGET.test("m.addEventListener?.('change', set)")).toBe(true)
+    LONG_LIVED_TARGET.lastIndex = 0
+    expect(VUEUSE_MANAGED.test('const reduced = useMediaQuery("(prefers-reduced-motion)")')).toBe(true)
+    expect(VUEUSE_MANAGED.test('el.addEventListener("click", fn)')).toBe(false)
+  })
+
+  it('every long-lived listener is removed or managed', () => {
+    expect(offenders()).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `ARCH-12` and `ARCH-07`, test-first. Two unrelated defects in one component — kept together because both are in `Carousel.vue` and separate PRs would collide.

## Dead aura code

`auraColors`, `defaultAura`, `activeAuraColor`, `outerAuraStyle` and the `withAlpha` helper computed a radial-gradient glow **the template never renders**. `auraColors` was also never written to, so `activeAuraColor` could only ever return the fallback.

About 20 lines computing a value nothing consumes — including a hardcoded `rgb(39, 169, 225)` duplicating the brand secondary token.

## Leaked listener

The reduced-motion preference subscribed to a `MediaQueryList` and never unsubscribed. The component unmounts on client-side navigation, the listener stays, and its closure keeps the whole component scope alive. A second visit adds another.

Replaced with `useMediaQuery` from `@vueuse/core` — already a dependency, unregisters with the effect scope. Behaviour is unchanged: still starts at the current preference, still updates on change.

## The test almost passed while the bug was there

The first version of the guard reported a clean tree. The call site is:

```js
m.addEventListener?.('change', set)
```

`?.` is **two characters**, and my pattern used `\??` — one optional `?`. It matched nothing, and the suite read as proof that nothing leaks.

A self-test now pins the optional-call form alongside the plain one. This is the second time a guard test needed a test of its own before it was worth anything.

## Scope of the check

Only listeners on targets that outlive the component: `window`, `document`, a `MediaQueryList`. One attached to an element in the component's own template dies with that element. Files using a `@vueuse` composable are exempt — those tear down with the scope.

One ESLint error fewer; baseline lowered to 356.

Refs: `ARCH-12`, `ARCH-07`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s