### PR TITLE
fix(a11y): reserve room for the sticky header when scrolling

### DIFF
--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -2,6 +2,18 @@
 /* Global smooth scrolling for in-page anchors */
 html { scroll-behavior: smooth; }
 
+/*
+ * Keep the sticky navigation bar (h-16, so 4rem) from covering whatever the
+ * browser scrolls to. Without this, following an in-page link puts the target
+ * heading behind the header, and — the part that actually breaks — tabbing
+ * backwards scrolls the focused element to exactly where the header sits, so
+ * it has focus and is invisible.
+ *
+ * Deliberately outside the reduced-motion block: the offset is needed for
+ * instant jumps just as much as for smooth ones.
+ */
+html { scroll-padding-top: 4rem; }
+
 /* Respect user preference to reduce motion */
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }

--- a/tests/a11y/scroll-padding.spec.ts
+++ b/tests/a11y/scroll-padding.spec.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * A sticky header covers whatever the browser scrolls to, unless
+ * `scroll-padding-top` reserves room for it. Two things land underneath it:
+ *
+ *   - anchor targets. The privacy page alone has 13 in-page links; following
+ *     one puts the heading behind the header, so the reader starts mid-section
+ *     with no idea they are in the right place.
+ *   - the focus ring when tabbing backwards. The browser scrolls the focused
+ *     element just into view, which is exactly where the header sits — the
+ *     element has focus and cannot be seen.
+ *
+ * The second is the accessibility failure: keyboard users lose track of focus
+ * entirely, and there is no visual cue that anything is wrong.
+ */
+
+const TOKENS = join(repoRoot, 'assets/css/tokens.css')
+const NAVBAR = join(repoRoot, 'components/features/navigation/NavigationBar.vue')
+
+function tokens(): string {
+  return readFileSync(TOKENS, 'utf8')
+}
+
+/** The Tailwind height class on the sticky header's inner row, in rem. */
+function headerHeightRem(): number {
+  const markup = readFileSync(NAVBAR, 'utf8')
+  const match = /class="[^"]*\bh-(\d+)\b[^"]*"/.exec(markup)
+  const steps = match?.[1]
+  if (steps === undefined) throw new Error('no h-<n> class found on the navigation bar')
+  // Tailwind's spacing scale is 0.25rem per step: h-16 is 4rem.
+  return Number(steps) * 0.25
+}
+
+describe('sticky header and scrolling', () => {
+  it('reads the header height from the markup', () => {
+    // Pinned so the assertion below compares against the real header rather
+    // than a number copied into this file once and forgotten.
+    expect(headerHeightRem()).toBeGreaterThan(0)
+  })
+
+  it('reserves room for the header when scrolling to an anchor', () => {
+    const declared = /scroll-padding-top:\s*([\d.]+)rem/.exec(tokens())?.[1]
+    expect(declared, 'scroll-padding-top is not set on html').toBeDefined()
+    expect(Number(declared)).toBeGreaterThanOrEqual(headerHeightRem())
+  })
+
+  it('still applies when smooth scrolling is disabled', () => {
+    // scroll-padding is independent of scroll-behavior: the offset matters for
+    // instant jumps too, including the reduced-motion path.
+    const css = tokens()
+    const paddingRule = /scroll-padding-top/.exec(css)?.index ?? -1
+    const reducedMotionBlock = /@media\s*\(prefers-reduced-motion/.exec(css)?.index ?? Infinity
+    expect(paddingRule).toBeGreaterThan(-1)
+    expect(paddingRule).toBeLessThan(reducedMotionBlock)
+  })
+})


### PR DESCRIPTION
Implements `A11Y-10`, test-first. One CSS declaration.

## The defect

`html` set `scroll-behavior: smooth` but no `scroll-padding-top`, while the navigation bar is sticky at `h-16` (4rem). **Anything the browser scrolls to landed behind it.**

Two consequences:

- **Anchor links.** The privacy page alone has 13. Following one put the target heading under the header, so the reader arrived mid-section with no confirmation they had jumped anywhere.
- **Tabbing backwards** — this is the actual accessibility failure. The browser scrolls a focused element *just* into view, which is precisely where the header sits. The element has focus and is invisible, with no cue that anything is wrong.

## The fix

```css
html { scroll-padding-top: 4rem; }
```

Matches `h-16` exactly. **Placed outside the reduced-motion block on purpose** — `scroll-padding` is independent of `scroll-behavior`, and the offset is needed for instant jumps just as much as smooth ones. A test asserts that placement, because tucking it into the smooth-scroll rule is the natural mistake.

## The test reads the header height from the markup

Rather than hardcoding `4rem`, it parses the `h-<n>` class off the navigation bar and converts via Tailwind's 0.25rem scale. Changing the header height now fails the test instead of silently misaligning every anchor on the site.

Suite: 44 tests, 11 files. Ratchet unchanged: 357 / 48 / 31.

Refs: `A11Y-10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s