### PR TITLE
fix(styles): remove utility classes that never resolved

### DIFF
--- a/components/features/home/carousel/Carousel.vue
+++ b/components/features/home/carousel/Carousel.vue
@@ -300,7 +300,7 @@ function withAlpha(rgb: string, a: number) {
           :icon="['fas','chevron-left']"
           variant="filled"
           size="lg"
-          class="shadow-xl shadow-black/40 ring-1 ring-black/20 cursor-pointer md:size-xl"
+          class="shadow-xl shadow-black/40 ring-1 ring-black/20 cursor-pointer"
           style="pointer-events: auto !important;"
           @click="(e: MouseEvent) => { e.stopPropagation(); prev(); }"
         />
@@ -309,7 +309,7 @@ function withAlpha(rgb: string, a: number) {
           :icon="['fas','chevron-right']"
           variant="filled"
           size="lg"
-          class="shadow-xl shadow-black/40 ring-1 ring-black/20 cursor-pointer md:size-xl"
+          class="shadow-xl shadow-black/40 ring-1 ring-black/20 cursor-pointer"
           style="pointer-events: auto !important;"
           @click="(e: MouseEvent) => { e.stopPropagation(); next(); }"
         />

--- a/components/features/home/server-addresses/ServerAddresses.vue
+++ b/components/features/home/server-addresses/ServerAddresses.vue
@@ -75,15 +75,15 @@ const onCopyBedrockPort = async () => {
         <!-- Decorative aura background (now via Tailwind utilities, incl. motion-reduce) -->
         <div
           aria-hidden="true"
-          class="pointer-events-none absolute inset-2 md:inset-1 lg:-inset-2 -z-10 rounded-3xl opacity-[0.52] lg:opacity-[0.58] blur-[22px] md:blur-[28px] lg:blur-[38px] [background:conic-gradient(from_180deg_at_50%_50%,var(--color-brand-accent)_0deg,var(--color-brand-secondary)_120deg,var(--color-brand-orange)_240deg,var(--color-brand-accent)_360deg)] animate-aura-breathe motion-reduce:animate-none [will-change:transform]"
+          class="pointer-events-none absolute inset-2 md:inset-1 lg:-inset-2 -z-10 rounded-3xl opacity-[0.52] lg:opacity-[0.58] blur-[22px] md:blur-[28px] lg:blur-[38px] [background:conic-gradient(from_180deg_at_50%_50%,var(--color-brand-accent)_0deg,var(--color-brand-secondary)_120deg,var(--color-brand-orange)_240deg,var(--color-brand-accent)_360deg)]"
         >
           <!-- Blob 1 -->
           <div
-            class="absolute inset-[-4%] md:inset-[-6%] lg:inset-[-12%] rounded-[inherit] pointer-events-none mix-blend-screen opacity-[0.24] translate-x-[-6%] translate-y-[-5%] scale-[0.98] md:scale-[1.02] lg:scale-[1.05] animate-blob-drift-1 motion-reduce:animate-none [background:radial-gradient(closest-side,color-mix(in_oklab,var(--color-brand-accent)_60%,white_40%)_0%,transparent_70%)] [will-change:transform,opacity]"
+            class="absolute inset-[-4%] md:inset-[-6%] lg:inset-[-12%] rounded-[inherit] pointer-events-none mix-blend-screen opacity-[0.24] translate-x-[-6%] translate-y-[-5%] scale-[0.98] md:scale-[1.02] lg:scale-[1.05] [background:radial-gradient(closest-side,color-mix(in_oklab,var(--color-brand-accent)_60%,white_40%)_0%,transparent_70%)]"
           />
           <!-- Blob 2 -->
           <div
-            class="absolute inset-[-4%] md:inset-[-6%] lg:inset-[-12%] rounded-[inherit] pointer-events-none mix-blend-screen opacity-[0.22] translate-x-[5%] translate-y-[3%] scale-[0.9] md:scale-[0.95] lg:scale-[0.98] animate-blob-drift-2 motion-reduce:animate-none [background:radial-gradient(closest-side,color-mix(in_oklab,var(--color-brand-secondary)_60%,white_40%)_0%,transparent_70%)] [will-change:transform,opacity]"
+            class="absolute inset-[-4%] md:inset-[-6%] lg:inset-[-12%] rounded-[inherit] pointer-events-none mix-blend-screen opacity-[0.22] translate-x-[5%] translate-y-[3%] scale-[0.9] md:scale-[0.95] lg:scale-[0.98] [background:radial-gradient(closest-side,color-mix(in_oklab,var(--color-brand-secondary)_60%,white_40%)_0%,transparent_70%)]"
           />
         </div>
         <div

--- a/tests/design-system/utility-classes.spec.ts
+++ b/tests/design-system/utility-classes.spec.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo, repoRoot } from '../helpers/sources'
+
+/**
+ * Tailwind emits a rule only for a class it can resolve. A name that resolves
+ * to nothing is not an error anywhere — not in the build, not in ESLint, not
+ * in the type checker. It renders as if it were absent.
+ *
+ * Two shapes of that were in the tree, both looking entirely plausible:
+ *
+ *   md:size-xl              `size-*` takes a spacing step (`size-10`) or a
+ *                           fraction, never a t-shirt size. The carousel
+ *                           arrows were meant to grow on desktop and never did.
+ *   animate-aura-breathe    an animation utility needs a keyframe, declared
+ *   animate-blob-drift-1/2  as `--animate-*` in @theme or an @keyframes block.
+ *                           Neither exists, so three decorative animations
+ *                           never ran — while the `motion-reduce:animate-none`
+ *                           beside them implies reduced motion was handled.
+ *
+ * Checked against the theme rather than a fixed list, so a keyframe added
+ * later makes its utility legal without editing this file.
+ */
+
+const SOURCE_DIRS = [
+  'components',
+  'pages',
+  'layouts',
+]
+
+/** Animation utilities Tailwind ships without any theme entry. */
+const BUILTIN_ANIMATIONS = new Set([
+  'none',
+  'spin',
+  'ping',
+  'pulse',
+  'bounce',
+])
+
+function themeAnimations(): Set<string> {
+  const css = readFileSync(join(repoRoot, 'assets/css/tailwind.css'), 'utf8')
+  const names = [...css.matchAll(/--animate-([a-z0-9-]+)\s*:/g)]
+    .map((match) => match[1])
+    .filter((name): name is string => name !== undefined)
+  const keyframes = [...css.matchAll(/@keyframes\s+([a-z0-9-]+)/g)]
+    .map((match) => match[1])
+    .filter((name): name is string => name !== undefined)
+  return new Set([...names, ...keyframes])
+}
+
+function templateFiles(): string[] {
+  return collectSourceFiles(SOURCE_DIRS, ['.vue']).concat([join(repoRoot, 'error.vue')])
+}
+
+function usages(pattern: RegExp): { file: string, value: string }[] {
+  const found: { file: string, value: string }[] = []
+  for (const file of templateFiles()) {
+    const text = readFileSync(file, 'utf8')
+    for (const match of text.matchAll(pattern)) {
+      const value = match[1]
+      if (value !== undefined) found.push({ file: relativeToRepo(file), value })
+    }
+  }
+  return found
+}
+
+describe('utility classes that resolve to nothing', () => {
+  it('finds files to check', () => {
+    expect(templateFiles().length).toBeGreaterThan(30)
+  })
+
+  it('every animate-* has a keyframe or is built in', () => {
+    const known = themeAnimations()
+    const dead = usages(/\banimate-([a-z][a-z0-9-]*)\b/g)
+      .filter((use) => !BUILTIN_ANIMATIONS.has(use.value) && !known.has(use.value))
+      .map((use) => `${use.file}: animate-${use.value}`)
+    expect([...new Set(dead)].sort()).toEqual([])
+  })
+
+  it('size-* takes a numeric step, not a t-shirt size', () => {
+    // `size-xl` is the shape of `text-xl` and `shadow-xl`, which is exactly
+    // why it looks right; the size utility has no such scale.
+    const dead = usages(/\bsize-(xs|sm|md|lg|xl|2xl|3xl|full|screen)\b/g)
+      .map((use) => `${use.file}: size-${use.value}`)
+    expect([...new Set(dead)].sort()).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `TW-06` and `TW-09`, test-first.

## Four classes that emitted no CSS

Tailwind produces a rule only for a class it can resolve. A name it cannot resolve is not an error anywhere — it renders as if absent.

**`md:size-xl`** (carousel arrows, ×2). `size-*` takes a spacing step (`size-10`) or a fraction, never a t-shirt size. It has the shape of `text-xl` and `shadow-xl`, which is exactly why it reads as correct. The arrows were meant to grow on desktop and never did.

Removed rather than guessed at — **what size was intended is not recoverable from the code**, and inventing one would be a design decision.

**`animate-aura-breathe`, `animate-blob-drift-1`, `animate-blob-drift-2`** on the decorative aura behind the server addresses. An animation utility needs a keyframe, declared as `--animate-*` in `@theme` or an `@keyframes` block. Neither exists. The gradients were always static.

## Two things that went with them

`motion-reduce:animate-none` on the same elements — with no animation to suppress it did nothing, while **implying reduced motion had been dealt with here**. That is the misleading part: a reviewer sees the pair and moves on.

`[will-change:transform]` — on an element that never animates, this only forces a compositing layer for no benefit.

The elements stay and still render their gradients. Reinstating the motion is a design decision: it needs keyframes someone has to author.

## The test

Checks animations against the theme rather than a fixed list, so adding a keyframe later makes its utility legal without editing the test. Tailwind's five built-ins (`none`, `spin`, `ping`, `pulse`, `bounce`) are exempt — `animate-pulse` is in use and legitimate.

Suite: 44 tests, 11 files. Ratchet unchanged: 357 / 48 / 31.

Refs: `TW-06`, `TW-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s