### PR TITLE
fix(image): stop asking the pipeline to re-encode an SVG

### DIFF
--- a/components/features/navigation/NavigationBar.vue
+++ b/components/features/navigation/NavigationBar.vue
@@ -109,7 +109,7 @@ onKeyStroke('Escape', () => closeMenus())
       <div class="flex h-16 items-center justify-between">
         <div class="flex items-center">
           <NuxtLinkLocale to="/" :aria-label="t('navigation.overview')" class="flex items-center gap-2 text-[var(--color-text)] no-underline hover:opacity-90 dark:text-[var(--color-text)]">
-            <NuxtImg src="images/logo.svg" :alt="t('accessibility.logo_alt')" width="40" height="40" class="h-10 w-10" format="webp" />
+            <NuxtImg src="images/logo.svg" :alt="t('accessibility.logo_alt')" width="40" height="40" class="h-10 w-10" />
             <GradientText variant="accent" tone="light" class="text-lg font-semibold">OneLiteFeather</GradientText>
           </NuxtLinkLocale>
         </div>

--- a/tests/design-system/image-formats.spec.ts
+++ b/tests/design-system/image-formats.spec.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * Asking the image pipeline to re-encode an SVG does nothing. Measured against
+ * the live proxy:
+ *
+ *   /images/logo.svg                                     image/svg+xml, 27106 B
+ *   /cdn-cgi/image/w=40,h=40,f=webp/images/logo.svg      image/svg+xml, 27047 B
+ *
+ * Cloudflare passes vector sources through untouched, so `format="webp"` adds
+ * a parameter that changes nothing — and, more usefully, would be wrong if it
+ * ever did work: rasterising a vector at 40px throws away the resolution
+ * independence that is the reason to ship an SVG.
+ *
+ * The same goes for `quality`, which has no meaning for a vector.
+ */
+
+const SOURCE_DIRS = [
+  'components',
+  'pages',
+  'layouts',
+]
+
+/** `<NuxtImg …>` and `<NuxtPicture …>` opening tags, attributes included. */
+const IMAGE_COMPONENT = /<Nuxt(?:Img|Picture)\b[^>]*>/gs
+const SVG_SOURCE = /src="[^"]*\.svg"/
+const RASTER_ONLY_MODIFIER = /\b(?:format|quality)="/
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue'])) {
+    const text = readFileSync(file, 'utf8')
+    for (const match of text.matchAll(IMAGE_COMPONENT)) {
+      const element = match[0]
+      if (!SVG_SOURCE.test(element)) continue
+      if (!RASTER_ONLY_MODIFIER.test(element)) continue
+      const line = text.slice(0, match.index).split('\n').length
+      found.push(`${relativeToRepo(file)}:${line}`)
+    }
+  }
+  return found
+}
+
+describe('vector sources', () => {
+  it('distinguishes vector from raster sources', () => {
+    // Guards the matcher itself: a broken SVG_SOURCE would silently exempt
+    // everything and this suite would pass on any tree.
+    expect(SVG_SOURCE.test('<NuxtImg src="images/logo.svg" format="webp" />')).toBe(true)
+    expect(SVG_SOURCE.test('<NuxtImg src="images/photo.png" format="webp" />')).toBe(false)
+    expect(RASTER_ONLY_MODIFIER.test('format="webp"')).toBe(true)
+    expect(RASTER_ONLY_MODIFIER.test('width="40" height="40"')).toBe(false)
+  })
+
+  it('carry no raster-only modifiers', () => {
+    expect(offenders()).toEqual([])
+  })
+})

--- a/tests/design-system/image-formats.spec.ts
+++ b/tests/design-system/image-formats.spec.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
 


### PR DESCRIPTION
Part of `PERF-06`, test-first. One attribute.

## Measured, not assumed

The navigation logo passed `format="webp"` to `NuxtImg` on a vector source. Against the live proxy:

```
/images/logo.svg                                  image/svg+xml, 27106 B
/cdn-cgi/image/w=40,h=40,f=webp/images/logo.svg   image/svg+xml, 27047 B
```

Cloudflare passes vector sources through untouched — the parameter changed nothing. And it would be **wrong if it ever did work**: rasterising at 40px discards the resolution independence that is the reason to ship an SVG.

## What this PR deliberately leaves alone

The finding also covers the 27 KB payload and the byte-identical copy at `public/favicon.svg`. I checked both and neither belongs in a small PR:

- **The size is real.** The file has no Inkscape metadata, no `sodipodi` attributes, no RDF block — it is dozens of `clipPath` elements and path data. Shrinking it needs `svgo` as a new dependency plus a visual check that nothing broke.
- **The duplicate is load-bearing.** `favicon.svg` is referenced from six places, including `site.webmanifest` and the team-profile avatar fallback. Collapsing it means deciding which path is canonical and touching all six.

Both are worth doing. Neither is a one-liner, and calling them done here would have been the wrong kind of tidy.

## The test

Rejects `format` and `quality` on any `NuxtImg`/`NuxtPicture` with an `.svg` source. A self-test pins the matcher — a broken `SVG_SOURCE` pattern would exempt everything and let the suite pass on any tree.

Suite: 52 tests, 14 files. Ratchet: 356 / 48 / 31.

Refs: part of `PERF-06`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s