### PR TITLE
fix(seo): point breadcrumb ancestors at the canonical locale root

### DIFF
--- a/composables/useArticleSeo.ts
+++ b/composables/useArticleSeo.ts
@@ -163,7 +163,7 @@ export function useArticleSeo(
   })
 
   useBreadcrumbs(() => [
-    { name: t('navigation.home'), url: `/${locale.value}/` },
+    { name: t('navigation.home'), url: `/${locale.value}` },
     { name: t('blog.overview.title'), url: `/${locale.value}/blog` },
     { name: blog.value?.title || '' }
   ])

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -27,7 +27,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` }, { name: t('blog.overview.title') }
+  { name: t('navigation.home'), url: `/${locale.value}` }, { name: t('blog.overview.title') }
 ])
 
 // Help Google identify the list of articles as a structured collection.

--- a/pages/bluemap.vue
+++ b/pages/bluemap.vue
@@ -21,7 +21,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` }, { name: t('bluemap.title') }
+  { name: t('navigation.home'), url: `/${locale.value}` }, { name: t('bluemap.title') }
 ])
 </script>
 

--- a/pages/community-poi/[...slug].vue
+++ b/pages/community-poi/[...slug].vue
@@ -35,7 +35,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` },
+  { name: t('navigation.home'), url: `/${locale.value}` },
   { name: t('community_poi.overview.title'), url: `/${locale.value}/community-poi/` },
   { name: title.value }
 ])

--- a/pages/community-poi/index.vue
+++ b/pages/community-poi/index.vue
@@ -27,7 +27,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` }, { name: t('community_poi.overview.title') }
+  { name: t('navigation.home'), url: `/${locale.value}` }, { name: t('community_poi.overview.title') }
 ])
 
 useSchemaOrg(() => {

--- a/pages/imprint.vue
+++ b/pages/imprint.vue
@@ -12,7 +12,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` }, { name: t('blog.imprint.title') }
+  { name: t('navigation.home'), url: `/${locale.value}` }, { name: t('blog.imprint.title') }
 ])
 </script>
 

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -12,7 +12,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` }, { name: t('blog.privacy.title') }
+  { name: t('navigation.home'), url: `/${locale.value}` }, { name: t('blog.privacy.title') }
 ])
 </script>
 

--- a/pages/team/[slug].vue
+++ b/pages/team/[slug].vue
@@ -76,7 +76,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` },
+  { name: t('navigation.home'), url: `/${locale.value}` },
   { name: t('team.title'), url: `/${locale.value}/team` },
   { name: member.value?.name || t('team.title') }
 ])

--- a/pages/team/index.vue
+++ b/pages/team/index.vue
@@ -25,7 +25,7 @@ usePageSeo({
 })
 
 useBreadcrumbs(() => [
-  { name: t('navigation.home'), url: `/${locale.value}/` }, { name: t('team.title') }
+  { name: t('navigation.home'), url: `/${locale.value}` }, { name: t('team.title') }
 ])
 
 // Expose the roster as an ItemList of Person entities. The stable per-member

--- a/tests/seo/breadcrumb-urls.spec.ts
+++ b/tests/seo/breadcrumb-urls.spec.ts
@@ -22,10 +22,7 @@ import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
  * of repetition that drifts.
  */
 
-const SOURCE_DIRS = [
-  'pages',
-  'composables',
-]
+const SOURCE_DIRS = ['pages', 'composables']
 
 /** `url: \`/${locale.value}/\`` — a locale root with a trailing slash. */
 const LOCALE_ROOT_WITH_SLASH = /url:\s*`\/\$\{locale\.value\}\/`/

--- a/tests/seo/breadcrumb-urls.spec.ts
+++ b/tests/seo/breadcrumb-urls.spec.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * Breadcrumb JSON-LD tells search engines which URL each ancestor lives at.
+ * When that differs from the page's own canonical, the two disagree about the
+ * same document.
+ *
+ * Measured live before the fix:
+ *
+ *   canonical on /de       https://onelitefeather.net/de
+ *   breadcrumb item        https://onelitefeather.net/de/
+ *
+ * `/de/` answers 200 rather than redirecting, so both URLs exist and every
+ * subpage was pointing its ancestor at the non-canonical one. Nuxt does not
+ * append a trailing slash by default and nothing here overrides that, so the
+ * canonical form is the one without.
+ *
+ * Checked against the source rather than rendered output because the value is
+ * a template literal built per page — nine of them, which is exactly the kind
+ * of repetition that drifts.
+ */
+
+const SOURCE_DIRS = [
+  'pages',
+  'composables',
+]
+
+/** `url: \`/${locale.value}/\`` — a locale root with a trailing slash. */
+const LOCALE_ROOT_WITH_SLASH = /url:\s*`\/\$\{locale\.value\}\/`/
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
+    const text = readFileSync(file, 'utf8')
+    const lines = text.split('\n')
+    lines.forEach((line, index) => {
+      if (LOCALE_ROOT_WITH_SLASH.test(line)) {
+        found.push(`${relativeToRepo(file)}:${index + 1}`)
+      }
+    })
+  }
+  return found
+}
+
+describe('breadcrumb ancestor URLs', () => {
+  it('recognises the trailing-slash form', () => {
+    // Without this the check could pass by matching nothing at all.
+    expect(LOCALE_ROOT_WITH_SLASH.test('{ name: t(\'navigation.home\'), url: `/${locale.value}/` }')).toBe(true)
+    expect(LOCALE_ROOT_WITH_SLASH.test('{ name: t(\'navigation.home\'), url: `/${locale.value}` }')).toBe(false)
+  })
+
+  it('point at the canonical locale root, without a trailing slash', () => {
+    expect(offenders()).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `SEO-05`, test-first. Nine call sites, one character each.

## The disagreement

Every page built its breadcrumb home entry as `` `/${locale}/` ``. Measured live:

| | |
|---|---|
| canonical on `/de` | `https://onelitefeather.net/de` |
| breadcrumb item | `https://onelitefeather.net/de/` |

`/de/` answers **200 rather than redirecting**, so both URLs exist side by side and nothing resolved the conflict. Every subpage told search engines its ancestor lived at a URL the site itself does not treat as canonical.

Nuxt appends no trailing slash by default and nothing here overrides that, so the form without is the canonical one.

## Verified after

The breadcrumb item on `/de/team`, `/de/blog` and `/de/imprint` now reads `https://onelitefeather.net/de` — matching each page's own canonical.

## Note on the check

It reads the source rather than rendered output. The value is a template literal repeated across nine files, which is exactly the duplication that drifts; a rendered check would need one request per page to cover the same ground.

One shell detail cost me a moment and is worth knowing: the pattern contains backticks, so `grep`/`sed` in a double-quoted context ran it as command substitution and reported **zero matches on a tree with nine**. The replacement went through Python instead.

Suite: 52 tests, 14 files. Ratchet: 356 / 48 / 31.

Refs: `SEO-05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s