### PR TITLE
fix(types): type the outside-click handler to the events it actually receives

### DIFF
--- a/components/features/navigation/LanguageSelector.vue
+++ b/components/features/navigation/LanguageSelector.vue
@@ -91,8 +91,11 @@ const onMenuKeydown = (e: KeyboardEvent) => {
   }
 };
 
-// Close dropdown when clicking outside (desktop variant)
-const onDocumentClick = (e: MouseEvent) => {
+// Close dropdown when clicking outside (desktop variant).
+// Registered on click and on touchstart, so `Event` is the only type that
+// describes what actually arrives. `e.target` is all this needs, and both
+// events carry it.
+const onDocumentClick = (e: Event) => {
   if (!isOpen.value) return;
   const target = e.target as Node | null;
   const btn = buttonRef.value;
@@ -105,14 +108,14 @@ const onDocumentClick = (e: MouseEvent) => {
 onMounted(() => {
   if (variant === 'desktop') {
     document.addEventListener('click', onDocumentClick);
-    document.addEventListener('touchstart', onDocumentClick, { passive: true as any });
+    document.addEventListener('touchstart', onDocumentClick, { passive: true });
   }
 });
 
 onBeforeUnmount(() => {
   if (variant === 'desktop') {
     document.removeEventListener('click', onDocumentClick);
-    document.removeEventListener('touchstart', onDocumentClick as any);
+    document.removeEventListener('touchstart', onDocumentClick);
   }
 });
 

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 356,
+  "eslintErrors": 354,
   "eslintWarnings": 48,
-  "typeErrors": 31
+  "typeErrors": 30
 }

--- a/tests/architecture/event-handler-types.spec.ts
+++ b/tests/architecture/event-handler-types.spec.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * One handler function, several event types. `click` delivers a MouseEvent,
+ * `touchstart` a TouchEvent — so a handler bound to both can only be typed to
+ * what they share, which is `Event`.
+ *
+ * Annotating it as the mouse variant compiles today as long as the body only
+ * touches `e.target`, which both events have. It stops being true the moment
+ * someone reaches for `e.button`, `e.clientX` or `e.ctrlKey`: TypeScript
+ * accepts all three, and on the touch path each one is `undefined` at runtime.
+ * The compiler has been told a fact about mobile that isn't so.
+ *
+ * The `as any` clause is the same defect wearing a different hat — it is what
+ * a mistyped handler needs in order to pass the registration call, so a cast
+ * inside `addEventListener`/`removeEventListener` marks the spot rather than
+ * fixing it. Worse for removal specifically: the cast changes the identity
+ * TypeScript reasons about, and an un-removed document listener outlives the
+ * component that registered it.
+ */
+
+const SOURCE_DIRS = ['components', 'pages', 'layouts', 'composables']
+
+const REGISTRATION = /(?:add|remove)EventListener\(\s*['"]([a-z]+)['"]\s*,\s*([A-Za-z_$][\w$]*)/g
+/** A cast anywhere inside a listener call — on the handler or on the options. */
+const CAST_IN_CALL = /(?:add|remove)EventListener\([^;]*?\bas any\b/g
+
+/** The parameter type a handler declares, or null if it declares none. */
+function parameterType(text: string, name: string): string | null {
+  const arrow = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=\\s*(?:async\\s+)?\\(\\s*\\w+\\s*:\\s*(\\w+)`)
+  const fn = new RegExp(`\\bfunction\\s+${name}\\s*\\(\\s*\\w+\\s*:\\s*(\\w+)`)
+  return (arrow.exec(text)?.[1] ?? fn.exec(text)?.[1]) ?? null
+}
+
+/** Handlers bound to more than one event type while typed to one of them. */
+function overNarrowHandlers(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
+    const text = readFileSync(file, 'utf8')
+    const events = new Map<string, Set<string>>()
+    for (const [, event, handler] of text.matchAll(REGISTRATION)) {
+      if (!events.has(handler!)) events.set(handler!, new Set())
+      events.get(handler!)!.add(event!)
+    }
+    for (const [handler, types] of events) {
+      if (types.size < 2) continue
+      const declared = parameterType(text, handler)
+      if (declared === null || declared === 'Event') continue
+      found.push(`${relativeToRepo(file)} — ${handler}(${declared}) on ${[...types].sort().join(', ')}`)
+    }
+  }
+  return found
+}
+
+function castsInListenerCalls(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      CAST_IN_CALL.lastIndex = 0
+      if (CAST_IN_CALL.test(line)) found.push(`${relativeToRepo(file)}:${index + 1}`)
+    })
+  }
+  return found
+}
+
+describe('event handler parameter types', () => {
+  it('reads registrations and declarations', () => {
+    // Without this the checks below could pass by matching nothing at all.
+    const sample = [
+      'const onDocumentClick = (e: MouseEvent) => {}',
+      "document.addEventListener('click', onDocumentClick)",
+      "document.addEventListener('touchstart', onDocumentClick, { passive: true as any })",
+    ].join('\n')
+
+    const pairs = [...sample.matchAll(REGISTRATION)].map(([, event, handler]) => `${event}:${handler}`)
+    expect(pairs).toEqual(['click:onDocumentClick', 'touchstart:onDocumentClick'])
+    expect(parameterType(sample, 'onDocumentClick')).toBe('MouseEvent')
+    expect(parameterType('function onKey(e: KeyboardEvent) {}', 'onKey')).toBe('KeyboardEvent')
+    expect(parameterType('const onAny = (e: Event) => {}', 'onAny')).toBe('Event')
+
+    // The cast sits in the options object here, not on the handler.
+    CAST_IN_CALL.lastIndex = 0
+    expect(CAST_IN_CALL.test("document.addEventListener('touchstart', fn, { passive: true as any })")).toBe(true)
+    CAST_IN_CALL.lastIndex = 0
+    expect(CAST_IN_CALL.test("document.removeEventListener('touchstart', fn)")).toBe(false)
+  })
+
+  it('handlers shared across event types are typed to Event', () => {
+    expect(overNarrowHandlers()).toEqual([])
+  })
+
+  it('no listener call needs an any-cast to compile', () => {
+    expect(castsInListenerCalls()).toEqual([])
+  })
+})

--- a/tests/architecture/event-handler-types.spec.ts
+++ b/tests/architecture/event-handler-types.spec.ts
@@ -21,7 +21,10 @@ import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
  * component that registered it.
  */
 
-const SOURCE_DIRS = ['components', 'pages', 'layouts', 'composables']
+const SOURCE_DIRS = ['components',
+'pages',
+'layouts',
+'composables']
 
 const REGISTRATION = /(?:add|remove)EventListener\(\s*['"]([a-z]+)['"]\s*,\s*([A-Za-z_$][\w$]*)/g
 /** A cast anywhere inside a listener call — on the handler or on the options. */
@@ -40,7 +43,8 @@ function overNarrowHandlers(): string[] {
   for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
     const text = readFileSync(file, 'utf8')
     const events = new Map<string, Set<string>>()
-    for (const [, event, handler] of text.matchAll(REGISTRATION)) {
+    for (const [, event,
+handler] of text.matchAll(REGISTRATION)) {
       if (!events.has(handler!)) events.set(handler!, new Set())
       events.get(handler!)!.add(event!)
     }
@@ -75,7 +79,8 @@ describe('event handler parameter types', () => {
       "document.addEventListener('touchstart', onDocumentClick, { passive: true as any })",
     ].join('\n')
 
-    const pairs = [...sample.matchAll(REGISTRATION)].map(([, event, handler]) => `${event}:${handler}`)
+    const pairs = [...sample.matchAll(REGISTRATION)].map(([, event,
+handler]) => `${event}:${handler}`)
     expect(pairs).toEqual(['click:onDocumentClick', 'touchstart:onDocumentClick'])
     expect(parameterType(sample, 'onDocumentClick')).toBe('MouseEvent')
     expect(parameterType('function onKey(e: KeyboardEvent) {}', 'onKey')).toBe('KeyboardEvent')


### PR DESCRIPTION
Implements `TS-05`, test-first.

## The claim the compiler was given

`LanguageSelector` closes its dropdown when you interact outside it, and registers the same handler twice:

```ts
const onDocumentClick = (e: MouseEvent) => { … }

document.addEventListener('click', onDocumentClick)
document.addEventListener('touchstart', onDocumentClick, { passive: true as any })
…
document.removeEventListener('touchstart', onDocumentClick as any)
```

`touchstart` delivers a **TouchEvent**, not a MouseEvent. The annotation is simply false on that path — and the two `as any` casts are what it took to get past the registration calls.

It works today only because the body reaches for `e.target` and nothing else, which both events carry. Add `e.button`, `e.clientX` or `e.ctrlKey` and TypeScript accepts all three while every one of them is `undefined` on a phone: the dropdown stops closing on tap-outside, with no compile error to say so.

`Event` is what the two registrations share, so that is the honest type. Both casts then come out on their own — including the one on removal, where a cast changes the identity TypeScript reasons about and an un-removed `document` listener would outlive its component.

## The guard

Not a spelling rule about `MouseEvent`. It groups every `addEventListener`/`removeEventListener` in `components`, `pages`, `layouts` and `composables` by handler name, and where a name is bound to **more than one event type** requires its declaration to say `Event`. A second check refuses `as any` anywhere inside a listener call, since that is the cast a mistyped handler needs in order to compile.

Both were red on this file before the change; the self-test pins the parsing so they cannot pass by matching nothing.

## Gates

Suite: 53 tests, 14 files. Build green. Ratchet moved **down** in both columns — ESLint 356 → 354 (the two `no-explicit-any`), TypeScript 31 → 30 — so `quality-baseline.json` drops with the commit and the gain cannot be given back.

Refs: `TS-05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s