### PR TITLE
fix(types): declare the page-meta title instead of asserting it at the reader

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,7 +17,9 @@ useHead(() => {
   return { link: h?.link ?? [], meta: h?.meta ?? [] }
 })
 // Only set a static <Title> when the route explicitly provides one via meta.
-const routeTitle = computed(() => (route.meta?.title ? t(route.meta.title as string) : null))
+// `title` is declared in types/page-meta.d.ts, so the compiler holds the pages
+// that set it to the same string contract this line relies on.
+const routeTitle = computed(() => (route.meta?.title ? t(route.meta.title) : null))
 
 // Expose the main navigation as schema.org SiteNavigationElement so Google
 // has a structured signal when picking SERP sitelinks.

--- a/tests/architecture/route-meta-contract.spec.ts
+++ b/tests/architecture/route-meta-contract.spec.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * `definePageMeta` writes a field, a layout or composable reads it back. Nuxt
+ * ships no declaration for the custom ones, so the value arrives as `unknown`
+ * from PageMeta's index signature and the reader has to assert what it is.
+ *
+ * That assertion is the whole contract. It lives at the reading end, where it
+ * cannot constrain the pages doing the writing — `definePageMeta({ title: 42 })`
+ * compiles, and `t()` is then handed a number at runtime. A cast is not a type
+ * check; it is a promise the compiler stops verifying.
+ *
+ * Augmenting `PageMeta` and `RouteMeta` moves the contract to where both ends
+ * see it, so the cast becomes unnecessary rather than merely unfashionable.
+ * The two rules below are therefore one rule read from both directions: every
+ * field we read must be declared, and no read may paper over a missing
+ * declaration with an assertion.
+ */
+
+const SOURCE_DIRS = ['components',
+  'pages',
+  'layouts',
+  'composables']
+const TYPE_DIRS = ['types']
+
+/** `route.meta.title`, `route.meta?.title` — the read side. */
+const META_READ = /\broute\.meta\s*\??\.\s*(\w+)/g
+/** The same read followed by an assertion. */
+const META_CAST = /\broute\.meta\s*\??\.\s*\w+\s+as\s+\w/g
+
+/** Field names declared inside a `PageMeta` or `RouteMeta` augmentation. */
+function declaredFields(): Set<string> {
+  const declared = new Set<string>()
+  for (const file of collectSourceFiles(TYPE_DIRS, ['.ts', '.d.ts'])) {
+    const text = readFileSync(file, 'utf8')
+    for (const block of text.matchAll(/interface\s+(?:Page|Route)Meta\s*\{([^}]*)\}/g)) {
+      for (const field of block[1]!.matchAll(/^\s*(\w+)\??\s*:/gm)) declared.add(field[1]!)
+    }
+  }
+  return declared
+}
+
+function undeclaredReads(): string[] {
+  const declared = declaredFields()
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      META_READ.lastIndex = 0
+      for (const [, field] of line.matchAll(META_READ)) {
+        if (declared.has(field!)) continue
+        found.push(`${relativeToRepo(file)}:${index + 1} — route.meta.${field}`)
+      }
+    })
+  }
+  return [...new Set(found)]
+}
+
+function assertedReads(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      META_CAST.lastIndex = 0
+      if (META_CAST.test(line)) found.push(`${relativeToRepo(file)}:${index + 1}`)
+    })
+  }
+  return found
+}
+
+describe('route meta contract', () => {
+  it('reads meta accesses and augmentations', () => {
+    // Without this the checks below could pass by matching nothing at all.
+    const line = 'const routeTitle = computed(() => (route.meta?.title ? t(route.meta.title as string) : null))'
+    expect([...line.matchAll(META_READ)].map(([, f]) => f)).toEqual(['title', 'title'])
+    META_CAST.lastIndex = 0
+    expect(META_CAST.test(line)).toBe(true)
+    META_CAST.lastIndex = 0
+    expect(META_CAST.test('t(route.meta.title)')).toBe(false)
+
+    const augmentation = 'declare module \'#app\' {\n  interface PageMeta {\n    title?: string\n  }\n}'
+    const fields = [...augmentation.matchAll(/interface\s+(?:Page|Route)Meta\s*\{([^}]*)\}/g)]
+      .flatMap((b) => [...b[1]!.matchAll(/^\s*(\w+)\??\s*:/gm)].map(([, f]) => f))
+    expect(fields).toEqual(['title'])
+  })
+
+  it('every field read off route.meta is declared', () => {
+    expect(undeclaredReads()).toEqual([])
+  })
+
+  it('no read asserts its own type', () => {
+    expect(assertedReads()).toEqual([])
+  })
+})

--- a/types/page-meta.d.ts
+++ b/types/page-meta.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Fields `definePageMeta` may set beyond the ones Nuxt declares itself.
+ *
+ * Without this, a custom field arrives at the reading end as `unknown` from
+ * PageMeta's index signature, and the reader has to assert what it is — an
+ * assertion that says nothing about the pages doing the writing. Declared
+ * here, both ends are held to the same contract by the compiler.
+ *
+ * `#app` covers `definePageMeta`; `vue-router` covers `useRoute().meta`,
+ * which is where the layout reads it back.
+ */
+
+declare module '#app' {
+  interface PageMeta {
+    /**
+     * i18n message key for the document title, resolved through `t()` in
+     * `layouts/default.vue`. A key, not the rendered title.
+     */
+    title?: string
+  }
+}
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    /** @see {@link import('#app').PageMeta.title} */
+    title?: string
+  }
+}
+
+export {}


### PR DESCRIPTION
Implements `TS-07`, test-first.

## Where the contract was kept

Five pages set a title through `definePageMeta`; the layout reads it back:

```ts
const routeTitle = computed(() => (route.meta?.title ? t(route.meta.title as string) : null))
```

Nuxt's `PageMeta` declares no `title`, so the value arrives as `unknown` from the index signature and that cast was the only place the contract existed. It sits at the **reading** end, where it cannot constrain the pages doing the writing.

## Measured, not argued

Before the change, `definePageMeta({ title: 42 })` in `pages/imprint.vue` compiled clean — `t()` would simply have received a number at runtime. After adding the declaration, the same edit fails at the setting site:

```
pages/imprint.vue(6,3): error TS2322: Type 'number' is not assignable to type 'string'.
```

That is the whole point: the error moved from nowhere to the line that caused it.

`types/page-meta.d.ts` augments `PageMeta` (for `definePageMeta`) and `RouteMeta` (for `useRoute().meta`, which is what the layout actually touches), and the cast comes out. Removing it introduces no new type error, which confirms the augmentation is being picked up rather than merely present.

## The guard

Two rules that are one rule from both sides: every field read off `route.meta` anywhere in `components`, `pages`, `layouts` or `composables` must be declared in a `PageMeta`/`RouteMeta` augmentation under `types/`, and no such read may assert its own type. Both were red on `layouts/default.vue:20`; the self-test pins the parsing so they cannot pass by matching nothing.

The first rule is the one that keeps paying: the next custom meta field gets a declaration, not a second cast.

## Gates

Suite: 53 tests, 14 files. Build green. Ratchet unchanged at 356 / 48 / 31 — the cast was not itself a reported error, so this buys a contract rather than a lower count.

Refs: `TS-07`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s