### PR TITLE
fix(i18n): translate the carousel's accessible names

### DIFF
--- a/components/features/home/carousel/Carousel.vue
+++ b/components/features/home/carousel/Carousel.vue
@@ -20,14 +20,24 @@ const props = withDefaults(defineProps<{
   loop?: boolean
   /** aspect in the form "16/9", "4/3", etc. Used for the container ratio */
   aspect?: string
+  /** Overrides the region name. Left out, the locale supplies one. */
   ariaLabel?: string
 }>(), {
   autoPlay: true,
   interval: 5000,
   loop: true,
   aspect: '16/9',
-  ariaLabel: 'Image Carousel'
+  // Deliberately undefined rather than a literal: a prop default is evaluated
+  // once, outside any locale, so the name has to come from `t()` below.
+  ariaLabel: undefined
 })
+
+const { t } = useI18n()
+
+// A prop default cannot be translated — it is evaluated once, outside any
+// locale. Falling back here instead means a caller that passes no name still
+// gets one in the reader's language.
+const resolvedAriaLabel = computed(() => props.ariaLabel || t('carousel.label'))
 
 const current = ref(0)
 const timer = ref<ReturnType<typeof setInterval> | null>(null)
@@ -191,7 +201,7 @@ const trackStyle = computed(() => ({
 const liveText = computed(() => {
   const slide = normalizedSlides.value[current.value]
   if (!slide) return ''
-  return getSlideAriaText(slide, current.value, slidesCount.value)
+  return getSlideAriaText(slide, current.value, slidesCount.value, t)
 })
 
 // Component mapping for dynamic rendering
@@ -214,7 +224,7 @@ const componentFor = (slide: NormalizedSlide) => {
   <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
   <section
     class="w-full"
-    :aria-label="ariaLabel"
+    :aria-label="resolvedAriaLabel"
     aria-roledescription="carousel"
     @keydown="onKeydown"
     @focusin="isHovering = true"
@@ -253,7 +263,7 @@ const componentFor = (slide: NormalizedSlide) => {
           :style="{ width: '100%', minWidth: '100%' }"
           role="group"
           aria-roledescription="slide"
-          :aria-label="getSlideAriaText(s, i, slidesCount)"
+          :aria-label="getSlideAriaText(s, i, slidesCount, t)"
           :aria-hidden="i !== current"
           :inert="i !== current ? true : undefined"
         >
@@ -271,7 +281,7 @@ const componentFor = (slide: NormalizedSlide) => {
       <!-- Controls -->
       <div class="absolute inset-x-0 top-0 bottom-10 z-50 flex items-center justify-between p-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100" style="pointer-events: none;">
         <NavigationIconButton
-          :aria-label="'Previous slide'"
+          :aria-label="t('carousel.previous_slide')"
           :icon="['fas','chevron-left']"
           variant="filled"
           size="lg"
@@ -280,7 +290,7 @@ const componentFor = (slide: NormalizedSlide) => {
           @click="(e: MouseEvent) => { e.stopPropagation(); prev(); }"
         />
         <NavigationIconButton
-          :aria-label="'Next slide'"
+          :aria-label="t('carousel.next_slide')"
           :icon="['fas','chevron-right']"
           variant="filled"
           size="lg"
@@ -298,7 +308,7 @@ const componentFor = (slide: NormalizedSlide) => {
             :key="i"
             type="button"
             class="group grid h-6 w-6 place-items-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
-            :aria-label="`Show slide ${i + 1}`"
+            :aria-label="t('carousel.show_slide', { index: i + 1 })"
             :aria-current="i === current ? 'true' : undefined"
             :aria-controls="`carousel-slide-${i}`"
             @click.stop="goTo(i)"

--- a/components/features/home/carousel/items/CarouselItemBlog.vue
+++ b/components/features/home/carousel/items/CarouselItemBlog.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import {computed} from 'vue'
 
+const { t } = useI18n()
+
 interface BlogItem {
   type: 'blog'
   title: string
@@ -59,7 +61,11 @@ const dateLabel = computed(() => {
         </div>
 
         <h3 class="mb-2 text-xl font-semibold leading-snug sm:text-2xl">
-          <NuxtLink :to="item.href" class="hover:underline" :aria-label="`Blog: ${item.title}`">
+          <NuxtLink
+            :to="item.href"
+            class="hover:underline"
+            :aria-label="t('carousel.blog_link', { title: item.title })"
+          >
             {{ item.title }}
           </NuxtLink>
         </h3>
@@ -71,7 +77,7 @@ const dateLabel = computed(() => {
         <NuxtLink
           :to="item.href"
           class="inline-flex items-center gap-2 rounded-md bg-white/90 px-3 py-1.5 text-sm font-medium text-black transition hover:bg-white"
-          :aria-label="`Zum Artikel: ${item.title}`"
+          :aria-label="t('carousel.read_article', { title: item.title })"
         >
           Lesen
           <font-awesome-icon :icon="['fas','arrow-right']" class="h-3.5 w-3.5" />

--- a/components/features/home/carousel/items/CarouselItemEvent.vue
+++ b/components/features/home/carousel/items/CarouselItemEvent.vue
@@ -2,6 +2,8 @@
 import {computed} from 'vue'
 import { NuxtLink } from '#components'
 
+const { t } = useI18n()
+
 interface EventItem {
   type: 'event'
   title: string
@@ -80,7 +82,7 @@ const timeRange = computed(() => {
             :is="item.href ? NuxtLink : 'div'"
             :to="item.href"
             class="hover:underline"
-            :aria-label="item.href ? `Event: ${item.title}` : undefined"
+            :aria-label="item.href ? t('carousel.event_link', { title: item.title }) : undefined"
           >
             {{ item.title }}
           </component>
@@ -94,7 +96,7 @@ const timeRange = computed(() => {
           v-if="item.href"
           :to="item.href"
           class="inline-flex items-center gap-2 rounded-md bg-white/90 px-3 py-1.5 text-sm font-medium text-black transition hover:bg-white"
-          :aria-label="`Zum Event: ${item.title}`"
+          :aria-label="t('carousel.to_event', { title: item.title })"
         >
           Details
           <font-awesome-icon :icon="['fas','arrow-right']" class="h-3.5 w-3.5" />

--- a/components/features/home/carousel/items/CarouselItemNews.vue
+++ b/components/features/home/carousel/items/CarouselItemNews.vue
@@ -2,6 +2,8 @@
 import {computed, computed as vComputed} from 'vue'
 import { NuxtLink } from '#components'
 
+const { t } = useI18n()
+
 interface NewsItem {
   type: 'news'
   title: string
@@ -64,7 +66,7 @@ const isSvg = vComputed(() => props.item.image ? /\.svg(\?|$)/i.test(props.item.
             :is="item.href ? NuxtLink : 'div'"
             :to="item.href"
             class="hover:underline"
-            :aria-label="item.href ? `News: ${item.title}` : undefined"
+            :aria-label="item.href ? t('carousel.news_link', { title: item.title }) : undefined"
           >
             {{ item.title }}
           </component>
@@ -78,7 +80,7 @@ const isSvg = vComputed(() => props.item.image ? /\.svg(\?|$)/i.test(props.item.
           v-if="item.href"
           :to="item.href"
           class="mt-3 inline-flex items-center gap-2 rounded-md bg-white/90 px-3 py-1.5 text-sm font-medium text-black transition hover:bg-white"
-          :aria-label="`Zur Meldung: ${item.title}`"
+          :aria-label="t('carousel.to_news', { title: item.title })"
         >
           Mehr
           <font-awesome-icon :icon="['fas','arrow-right']" class="h-3.5 w-3.5" />

--- a/components/features/sponsoring/Sponsoring.vue
+++ b/components/features/sponsoring/Sponsoring.vue
@@ -113,7 +113,7 @@ watch(
                 <button
                   type="button"
                   class="rounded-full cursor-pointer p-2 text-neutral-600 dark:text-neutral-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-secondary"
-                  :aria-label="t('carousel.prev') || 'Zurück'"
+                  :aria-label="t('carousel.prev')"
                   @click="prev"
                 >
                   ‹
@@ -121,7 +121,7 @@ watch(
                 <button
                   type="button"
                   class="rounded-full cursor-pointer p-2 text-neutral-600 dark:text-neutral-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-secondary"
-                  :aria-label="t('carousel.next') || 'Weiter'"
+                  :aria-label="t('carousel.next')"
                   @click="next"
                 >
                   ›

--- a/composables/useCarousel.ts
+++ b/composables/useCarousel.ts
@@ -95,12 +95,22 @@ export function isPoiSlide(slide: NormalizedSlide): slide is PoiSlide {
 }
 
 /**
+ * The subset of vue-i18n's `t` these helpers need.
+ *
+ * Passed in rather than reached for: `useI18n()` is only valid inside setup,
+ * and these are pure functions called from a template. Taking the translator
+ * as an argument keeps them testable without a Nuxt runtime and keeps the
+ * wording in the locale files where both languages can see it.
+ */
+export type TranslateSlideText = (key: string, named: Record<string, unknown>) => string
+
+/**
  * Extracts a label text from a slide for accessibility
  */
-export function getSlideLabel(slide: NormalizedSlide): string {
+export function getSlideLabel(slide: NormalizedSlide, t: TranslateSlideText): string {
   switch (slide.type) {
     case 'image':
-      return slide.alt || 'Image'
+      return slide.alt || t('carousel.image_fallback', {})
     case 'blog':
       return slide.title
     case 'news':
@@ -110,15 +120,26 @@ export function getSlideLabel(slide: NormalizedSlide): string {
     case 'poi':
       return slide.title
     default:
-      return 'Slide'
+      return t('carousel.slide_fallback', {})
   }
 }
 
 /**
- * Generates ARIA text for a slide including position
+ * Generates ARIA text for a slide including position.
+ *
+ * The carousel's live region reads this out on every rotation, so the position
+ * wording is the most-heard string in the component — and was hardcoded
+ * English regardless of locale.
  */
-export function getSlideAriaText(slide: NormalizedSlide, index: number, total: number): string {
-  const label = getSlideLabel(slide)
-  return `Slide ${index + 1} of ${total}: ${label}`
+export function getSlideAriaText(
+  slide: NormalizedSlide,
+  index: number,
+  total: number,
+  t: TranslateSlideText
+): string {
+  return t('carousel.slide_position', {
+    index: index + 1,
+    total,
+    label: getSlideLabel(slide, t)
+  })
 }
-

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -21,7 +21,20 @@
   },
   "carousel": {
     "prev": "Zurück",
-    "next": "Weiter"
+    "next": "Weiter",
+    "label": "Bilderkarussell",
+    "previous_slide": "Vorheriges Bild",
+    "next_slide": "Nächstes Bild",
+    "show_slide": "Bild {index} anzeigen",
+    "slide_position": "Bild {index} von {total}: {label}",
+    "slide_fallback": "Bild",
+    "image_fallback": "Bild",
+    "blog_link": "Blog: {title}",
+    "read_article": "Zum Artikel: {title}",
+    "event_link": "Event: {title}",
+    "to_event": "Zum Event: {title}",
+    "news_link": "News: {title}",
+    "to_news": "Zur Meldung: {title}"
   },
   "layouts": {
     "title": "Titel"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -21,7 +21,20 @@
   },
   "carousel": {
     "prev": "Previous",
-    "next": "Next"
+    "next": "Next",
+    "label": "Image Carousel",
+    "previous_slide": "Previous slide",
+    "next_slide": "Next slide",
+    "show_slide": "Show slide {index}",
+    "slide_position": "Slide {index} of {total}: {label}",
+    "slide_fallback": "Slide",
+    "image_fallback": "Image",
+    "blog_link": "Blog: {title}",
+    "read_article": "Read article: {title}",
+    "event_link": "Event: {title}",
+    "to_event": "Go to event: {title}",
+    "news_link": "News: {title}",
+    "to_news": "Go to news item: {title}"
   },
   "layouts": {
     "title": "Title"

--- a/tests/i18n/bound-attributes.spec.ts
+++ b/tests/i18n/bound-attributes.spec.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+import { getSlideAriaText } from '../../composables/useCarousel'
+
+/**
+ * The bound form of a text attribute is an expression, so a string literal
+ * inside it looks like code and reads like content. `:aria-label="'Next
+ * slide'"` is exactly as untranslated as `aria-label="Next slide"`, but it
+ * survives a search for the static form.
+ *
+ * Accessible names are where this hurts most. Nothing on screen shows them, so
+ * the page can look fully translated while a screen reader announces control
+ * names in the wrong language — which is what the carousel did in both
+ * directions at once: English chrome ("Previous slide", "Slide 1 of 5") and
+ * German link names ("Zum Artikel: …") shipped together, so neither locale was
+ * ever right.
+ *
+ * Not covered: prop defaults. `withDefaults(…, { ariaLabel: 'Image Carousel' })`
+ * is user-visible text and no attribute rule reaches it.
+ */
+
+const SOURCE_DIRS = ['components',
+  'pages',
+  'layouts']
+
+/** The bound form: `:aria-label="…"`, `:title="…"`. */
+const BOUND_TEXT_ATTRIBUTE = /(?<![\w.@-]):(aria-label|title)="([^"]*)"/g
+
+/**
+ * Text left in an expression once every `t(…)` call is removed. Interpolated
+ * `${…}` holes are stripped too — those carry data, not wording.
+ */
+function untranslatedText(expression: string): string[] {
+  const withoutTranslations = expression.replace(/\bt\(\s*[^)]*\)/g, '')
+  const remaining: string[] = []
+  for (const literal of withoutTranslations.matchAll(/'([^']*)'|`([^`]*)`/g)) {
+    const body = (literal[1] ?? literal[2] ?? '').replace(/\$\{[^}]*\}/g, '')
+    if (/[A-Za-z]/.test(body)) remaining.push(body.trim())
+  }
+  return remaining
+}
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue'])) {
+    const relative = relativeToRepo(file)
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      BOUND_TEXT_ATTRIBUTE.lastIndex = 0
+      for (const [, attribute,
+expression] of line.matchAll(BOUND_TEXT_ATTRIBUTE)) {
+        for (const raw of untranslatedText(expression!)) {
+          found.push(`${relative}:${index + 1} — :${attribute} carries "${raw}"`)
+        }
+      }
+    })
+  }
+  return found
+}
+
+describe('bound text attributes', () => {
+  it('separates wording from data and from t() calls', () => {
+    // Without this the check could pass by matching nothing at all.
+    expect(untranslatedText("'Previous slide'")).toEqual(['Previous slide'])
+    expect(untranslatedText('`Zum Artikel: ${item.title}`')).toEqual(['Zum Artikel:'])
+    // Interpolation alone is data, not wording.
+    expect(untranslatedText('`${item.title}`')).toEqual([])
+    // Already translated, including a ternary over two calls.
+    expect(untranslatedText("t('carousel.prev')")).toEqual([])
+    expect(untranslatedText("copied ? t('article.copied') : t('article.copy_link')")).toEqual([])
+    // A plain reference carries no wording of its own.
+    expect(untranslatedText('rawValue')).toEqual([])
+
+    const line = '<button :aria-label="\'Next slide\'" :title="t(\'x.y\')">'
+    BOUND_TEXT_ATTRIBUTE.lastIndex = 0
+    expect([...line.matchAll(BOUND_TEXT_ATTRIBUTE)].map(([, a]) => a)).toEqual(['aria-label', 'title'])
+  })
+
+  it('no bound title or aria-label carries untranslated wording', () => {
+    expect(offenders()).toEqual([])
+  })
+})
+
+describe('carousel slide announcements', () => {
+  it('delegates its wording to the translator instead of formatting English', () => {
+    const calls: Array<[string, Record<string, unknown> | undefined]> = []
+    const t = (key: string, named?: Record<string, unknown>) => {
+      calls.push([key, named])
+      return `«${key}»`
+    }
+
+    const text = getSlideAriaText({ type: 'image', src: '/a.png', alt: 'Sonnenaufgang' }, 0, 5, t)
+
+    // The live region reads this out on every rotation, so the position
+    // wording has to come from the locale, not from a template literal.
+    expect(calls).toEqual([['carousel.slide_position', { index: 1, total: 5, label: 'Sonnenaufgang' }]])
+    expect(text).toBe('«carousel.slide_position»')
+  })
+})


### PR DESCRIPTION
Companion to #234, which covered the static attribute form. This is the bound form — `:aria-label="'Next slide'"` is exactly as untranslated as `aria-label="Next slide"`, but it survives a search for the static one.

## Wrong in both directions at once

The carousel shipped English chrome and German content labels together, so **neither locale was ever right**:

| | before | |
|---|---|---|
| `Carousel.vue` | `'Previous slide'`, `'Next slide'`, `` `Show slide ${i+1}` ``, `ariaLabel: 'Image Carousel'` | English on `/de` |
| `useCarousel.ts` | `` `Slide ${index+1} of ${total}: ${label}` `` | English on `/de` |
| `CarouselItem{Blog,Event,News}` | `` `Zum Artikel: …` ``, `` `Zum Event: …` ``, `` `Zur Meldung: …` `` | German on `/en` |

The `slide_position` string is the one that matters most: it feeds the `aria-live="polite"` region, so a screen reader re-reads it on **every rotation** — five times a minute at the default interval, in the wrong language.

Two more turned up that the finding didn't name: `Sponsoring.vue` had `t('carousel.prev') || 'Zurück'`. `t()` never returns anything falsy — it echoes the key when a message is missing — so those fallbacks were unreachable German. Deleted rather than translated.

## Verified rendered, not just changed

Dev server, both locales:

```
/de   aria-label="Bild 1 von 5: Spawn-Bereich auf unserem Server (Screenshot)"
      aria-label="Vorheriges Bild"   aria-label="Zum Artikel: …"
/en   aria-label="Slide 1 of 5: Spawn area on our server (screenshot)"
      aria-label="Previous slide"    aria-label="Read article: …"
```

English output is unchanged where it was already English — the new `en` values reproduce the old literals exactly — so the only behavioural change per locale is the half that was wrong.

One leftover is visible in that run and is *not* this PR's: `/en` still renders `aria-label="Startseiten-Highlight-Karussell"` on the carousel region. That is the static attribute #234 fixes, which confirms the two changes are genuinely disjoint.

## Two design points

`getSlideAriaText` takes the translator as an argument instead of reaching for `useI18n()`, which is only valid inside setup — it stays a pure function, testable without a Nuxt runtime, with the wording in the locale files where both languages can see it.

`ariaLabel` loses its `'Image Carousel'` default and gains `undefined` plus a `t()` fallback. A prop default is evaluated once, outside any locale, so it can never be translated; the comment says so, since `ariaLabel: undefined` otherwise looks like an oversight.

## The guard

Strips every `t(…)` call and every `${…}` hole from a bound `:aria-label`/`:title` expression, then flags whatever letters remain — wording, as opposed to data or an already-translated call. Red on all eleven before the change. Alongside it, a behavioural test drives `getSlideAriaText` with a recording translator and asserts it *delegates* rather than formatting English itself, which no grep could establish.

Still not covered, and said so in the file: prop defaults. No attribute rule reaches `withDefaults(…, { ariaLabel: '…' })`.

## Gates

Suite: 66 tests, 19 files. Build green. Ratchet unchanged at 354 / 48 / 30 — one wrapped line and an explicit `undefined` default keep it there.

Refs: `I18N-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s