### PR TITLE
fix(components): keep navigation props reactive via withDefaults

### DIFF
--- a/components/base/buttons/NavigationIconButton.vue
+++ b/components/base/buttons/NavigationIconButton.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import IconFa from '~/components/base/icons/IconFa.vue';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   icon: string | [string,string];
   ariaLabel?: string;
   variant?: 'standard' | 'filled' | 'tonal' | 'outlined';
@@ -10,14 +10,17 @@ const props = defineProps<{
    * Sichtbarkeit/Ergonomie: Größe des Buttons (und des Icons)
    */
   size?: 'sm' | 'md' | 'lg' | 'xl';
-}>();
+}>(), {
+  ariaLabel: undefined,
+  variant: 'standard',
+  size: 'md'
+});
 
 const emit = defineEmits<{
   click: [event: MouseEvent];
 }>();
 
-const variant = props.variant ?? 'standard';
-const size = computed(() => props.size ?? 'md');
+const size = computed(() => props.size);
 
 const btnSizeClass = computed(() => ({
   sm: 'h-8 w-8',

--- a/components/features/navigation/LanguageSelector.vue
+++ b/components/features/navigation/LanguageSelector.vue
@@ -4,18 +4,18 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faLanguage, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 const { t } = useI18n();
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   variant?: 'desktop' | 'mobile';
-}>();
-
-const variant = props.variant ?? 'desktop';
+}>(), {
+  variant: 'desktop'
+});
 const { locale, locales } = useI18n();
 const isOpen = ref(false);
 const buttonRef = ref<HTMLButtonElement | null>(null);
 const menuRef = ref<HTMLElement | null>(null);
 const initialFocus = ref<'first' | 'last'>('first');
-const buttonId = computed(() => `lang-button-${variant}`);
-const dropdownId = computed(() => `lang-menu-${variant}`);
+const buttonId = computed(() => `lang-button-${props.variant}`);
+const dropdownId = computed(() => `lang-menu-${props.variant}`);
 
 const availableLocales = computed(() => locales.value.filter((i: any) => i.code !== locale.value));
 const currentLocale = computed(() => locales.value.find((i: any) => i.code === locale.value));
@@ -106,14 +106,14 @@ const onDocumentClick = (e: Event) => {
 };
 
 onMounted(() => {
-  if (variant === 'desktop') {
+  if (props.variant === 'desktop') {
     document.addEventListener('click', onDocumentClick);
     document.addEventListener('touchstart', onDocumentClick, { passive: true });
   }
 });
 
 onBeforeUnmount(() => {
-  if (variant === 'desktop') {
+  if (props.variant === 'desktop') {
     document.removeEventListener('click', onDocumentClick);
     document.removeEventListener('touchstart', onDocumentClick);
   }

--- a/components/features/navigation/NavigationBar.vue
+++ b/components/features/navigation/NavigationBar.vue
@@ -11,13 +11,13 @@ const { t, locale } = useI18n();
 const runtimeConfig = useRuntimeConfig();
 const route = useRoute()
 
-const props = defineProps<{
+withDefaults(defineProps<{
   elevation?: 0 | 1 | 2 | 3 | 4 | 5;
   variant?: 'top' | 'bottom';
-}>();
-
-const elevation = props.elevation ?? 2;
-const variant = props.variant ?? 'top';
+}>(), {
+  elevation: 2,
+  variant: 'top'
+});
 
 const mobileMenuOpen = ref(false);
 const openGroup = ref<string | null>(null);

--- a/components/features/navigation/NavigationItem.vue
+++ b/components/features/navigation/NavigationItem.vue
@@ -3,19 +3,21 @@ import { computed } from '#imports';
 import IconFa from '~/components/base/icons/IconFa.vue';
 const { t } = useI18n();
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   textKey: string;
   path: string;
   icon?: string | [string, string];
   variant?: 'desktop' | 'mobile' | 'bottom';
-}>();
+}>(), {
+  icon: undefined,
+  variant: 'desktop'
+});
 
 const emit = defineEmits<{
   click: [];
 }>();
 
 const route = useRoute();
-const variant = props.variant ?? 'desktop';
 
 const isActive = computed(() => {
   return route.path === props.path || route.path.startsWith(props.path + '/');

--- a/tests/architecture/frozen-props.spec.ts
+++ b/tests/architecture/frozen-props.spec.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * `const variant = props.variant ?? 'top'` reads the prop once, when setup
+ * runs, and never again. It looks like the reactive destructuring the Vue
+ * compiler rewrites, but that only applies *inside* `defineProps()` — this is
+ * an ordinary property access, and the compiler leaves it alone.
+ *
+ * Everything downstream inherits the staleness. A `computed` that closes over
+ * the constant has no reactive dependency to track, so it never recomputes; a
+ * `v-if` on it never re-evaluates. The component renders whatever the parent
+ * passed on the first render, forever.
+ *
+ * `withDefaults(defineProps<…>(), { … })` puts the fallback where the compiler
+ * can see it and leaves `props.variant` reactive at every read.
+ *
+ * Worth stating plainly: no call site in this repository binds these props
+ * dynamically today, so nothing is currently rendering stale. The rule earns
+ * its keep by making sure the first one that does isn't the way this is found
+ * out — a stale `v-if` fails silently, with no error and no wrong-looking
+ * code at the call site.
+ */
+
+const SOURCE_DIRS = ['components',
+  'pages',
+  'layouts']
+
+/** Top-level (unindented, so outside any function) reads of a prop. */
+const FROZEN_PROP = /^const\s+(\w+)\s*=\s*props\.(\w+)/
+/** Destructuring `props` outside `defineProps()` drops reactivity the same way. */
+const DESTRUCTURED_PROPS = /^const\s*\{[^}]*\}\s*=\s*props\b/
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue'])) {
+    const relative = relativeToRepo(file)
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      const frozen = FROZEN_PROP.exec(line)
+      if (frozen) found.push(`${relative}:${index + 1} — ${frozen[1]} frozen from props.${frozen[2]}`)
+      else if (DESTRUCTURED_PROPS.test(line)) found.push(`${relative}:${index + 1} — props destructured`)
+    })
+  }
+  return found
+}
+
+describe('prop reactivity', () => {
+  it('tells a frozen read from a reactive one', () => {
+    // Without this the check could pass by matching nothing at all.
+    expect(FROZEN_PROP.exec("const variant = props.variant ?? 'top';")?.[2]).toBe('variant')
+    expect(DESTRUCTURED_PROPS.test('const { slides, loop } = props')).toBe(true)
+
+    // A computed re-reads the prop on every evaluation — the correct form, and
+    // the one already used for `size` two lines below the frozen `variant`.
+    expect(FROZEN_PROP.test("const size = computed(() => props.size ?? 'md');")).toBe(false)
+    // Declaring the props is not reading them.
+    expect(FROZEN_PROP.test('const props = defineProps<{ variant?: string }>();')).toBe(false)
+    // Indented, so inside a function: evaluated per call, not once at setup.
+    expect(FROZEN_PROP.test('  const target = props.path')).toBe(false)
+  })
+
+  it('no prop is frozen into a setup-time constant', () => {
+    expect(offenders()).toEqual([])
+  })
+})

--- a/tests/architecture/prop-reactivity.spec.ts
+++ b/tests/architecture/prop-reactivity.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import NavigationIconButton from '../../components/base/buttons/NavigationIconButton.vue'
+
+/**
+ * The static check in `frozen-props.spec.ts` says the pattern is gone. This
+ * one says the behaviour it cost us is back: change a prop after the first
+ * render and watch the output follow.
+ *
+ * It matters because a frozen prop fails *silently*. There is no error, no
+ * warning, and the call site looks right — the component simply keeps
+ * rendering what it was handed first. A grep can prove the shape of the code;
+ * only a re-render can prove the shape was the thing that mattered.
+ *
+ * `NavigationIconButton` is the subject because its `variant` drives a class
+ * binding directly, so one assertion covers the whole path from prop to DOM.
+ * Its sibling components freeze the same prop behind a `v-if`, which fails the
+ * same way for the same reason.
+ */
+
+const FILLED = 'bg-[var(--color-brand-secondary)]'
+const OUTLINED = 'border-[var(--color-border)]'
+
+describe('prop changes reach the DOM', () => {
+  it('re-renders when variant changes after mount', async () => {
+    const wrapper = mount(NavigationIconButton, {
+      props: { icon: ['fas', 'chevron-left'], variant: 'filled' },
+      global: { stubs: { IconFa: true } }
+    })
+
+    expect(wrapper.html()).toContain(FILLED)
+    expect(wrapper.html()).not.toContain(OUTLINED)
+
+    await wrapper.setProps({ variant: 'outlined' })
+
+    // Frozen, this second pair fails while the first still passes — the
+    // component renders the variant it was born with.
+    expect(wrapper.html()).toContain(OUTLINED)
+    expect(wrapper.html()).not.toContain(FILLED)
+  })
+
+  it('falls back to the declared default when the prop is omitted', async () => {
+    const wrapper = mount(NavigationIconButton, {
+      props: { icon: ['fas', 'chevron-left'] },
+      global: { stubs: { IconFa: true } }
+    })
+
+    // 'standard' carries no variant class of its own.
+    expect(wrapper.html()).not.toContain(FILLED)
+    expect(wrapper.html()).not.toContain(OUTLINED)
+
+    await wrapper.setProps({ variant: 'tonal' })
+    expect(wrapper.html()).toContain('bg-[var(--color-surface)]/60')
+  })
+})


### PR DESCRIPTION
Implements `ARCH-09`, test-first.

## What the pattern costs

Five constants across four components:

```ts
const props = defineProps<{ variant?: 'top' | 'bottom' }>()
const variant = props.variant ?? 'top'      // read once, at setup
```

This *looks* like the reactive destructuring the Vue compiler rewrites, but that only applies inside `defineProps()`. Here it is an ordinary property access and the compiler leaves it alone — so `v-if="variant === 'top'"` and `computed(() => \`lang-button-${variant}\`)` have no dependency to track and never re-evaluate.

`NavigationIconButton` makes the point on its own: `variant` was frozen, and two lines below it `size` was written correctly as `computed(() => props.size ?? 'md')`. Same file, same kind of prop, two different answers.

## Latent, not live — said plainly

**No call site in this repository binds these props dynamically today.** Every one is a literal (`variant="mobile"`, `variant="filled"`), so nothing is currently rendering stale. This is a fix for the next call site, not for a bug users are hitting.

That is precisely why it is worth a guard rather than a comment: a frozen prop fails *silently*. No error, no warning, and the call site looks correct — the component just keeps rendering what it was handed first.

## Proved by re-render, not by grep

A static check can show the pattern is gone. It cannot show that the pattern was the thing that mattered. So there is a mounted component test that changes `variant` after the first render:

```
before the fix:  ✓ initial render is 'filled'
                 × after setProps({ variant: 'outlined' }) — expected html to contain 'border-[var(--color-border)]'
after the fix:   ✓ both
```

That failure shape is the bug itself: the first assertion passes, the second does not. Verified by stashing the component change and re-running against the same test.

## The guard

Flags any top-level `const x = props.y` and any `const { … } = props` outside `defineProps()` across `components`, `pages` and `layouts`. Red on all five. The self-test pins what must *not* match — a `computed(() => props.size)`, the `defineProps` line itself, and an indented read inside a function, which is evaluated per call rather than once.

## Note on the diff

`NavigationBar` loses its `const props` binding entirely, since `elevation` and `variant` were its only two props and the template reads them directly. `NavigationItem` and `NavigationIconButton` gain explicit `undefined` defaults for their genuinely optional props, which is what `vue/require-default-prop` asks for and keeps the ratchet where it was.

## Gates

Suite: 69 tests, 21 files. Build green. Ratchet unchanged at 354 / 48 / 30.

Refs: `ARCH-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s