### PR TITLE
perf(pages): defer below-the-fold hydration through Nuxt's Lazy prefix

### DIFF
--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { defineAsyncComponent } from 'vue'
 import {definePageMeta} from "#imports";
 import type { BlogArticle } from "~/types/blog";
 import UiChip from '~/components/base/Chip.vue'
@@ -13,7 +12,6 @@ definePageMeta({
 });
 
 const { blog, authors } = await useBlogArticle()
-const LazySocialMediaShare = defineAsyncComponent(() => import('~/components/features/blog/SocialMediaShare.vue'))
 
 // All Article-level SEO (meta tags, Article JSON-LD, breadcrumbs, OG
 // image) lives in useArticleSeo — keeps this page focused on view code.
@@ -137,7 +135,7 @@ useHead(() => {
         <!-- Social Media Sharing Buttons -->
         <section class="mt-8 border-t border-neutral-200 dark:border-neutral-800 pt-6" :aria-label="t('article.share')">
           <h2 class="sr-only">{{ t('article.share') }}</h2>
-          <LazySocialMediaShare
+          <LazyFeaturesBlogSocialMediaShare
             :url="shareUrl"
             :title="blog?.title"
             :description="blog?.description || ''"

--- a/pages/community-poi/[...slug].vue
+++ b/pages/community-poi/[...slug].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, definePageMeta } from '#imports'
+import { computed, definePageMeta } from '#imports'
 import CommunityPoiStatusBadge from '~/components/features/community-poi/CommunityPoiStatusBadge.vue'
 import CommunityPoiCategoryBadge from '~/components/features/community-poi/CommunityPoiCategoryBadge.vue'
 import CommunityPoiProgressBar from '~/components/features/community-poi/CommunityPoiProgressBar.vue'
@@ -16,11 +16,6 @@ definePageMeta({
 
 const { poi } = await useCommunityPoiDetail()
 
-const LazyGallery = defineAsyncComponent(() => import('~/components/features/community-poi/CommunityPoiGallery.vue'))
-const LazySchematics = defineAsyncComponent(() => import('~/components/features/community-poi/CommunityPoiSchematicList.vue'))
-const LazyLitematicaHelp = defineAsyncComponent(() => import('~/components/features/community-poi/CommunityPoiLitematicaHelp.vue'))
-const LazyBluemap = defineAsyncComponent(() => import('~/components/features/community-poi/CommunityPoiBluemap.vue'))
-const LazyCollaboration = defineAsyncComponent(() => import('~/components/features/community-poi/CommunityPoiCollaboration.vue'))
 
 const title = computed(() => poi.value?.title || t('community_poi.overview.title'))
 const description = computed(() => poi.value?.summary || t('community_poi.overview.description'))
@@ -158,7 +153,7 @@ const progressSectionClass = [
         <CommunityPoiMeta :poi="poi" />
       </section>
 
-      <LazyBluemap
+      <LazyFeaturesCommunityPoiBluemap
         v-if="poi.coordinates"
         :title="poi.title"
         :coordinates="poi.coordinates"
@@ -172,18 +167,18 @@ const progressSectionClass = [
         <h2 class="mb-3 text-xl font-semibold text-neutral-900 dark:text-neutral-50">
           {{ t('community_poi.gallery.title') }}
         </h2>
-        <LazyGallery :images="poi.gallery" />
+        <LazyFeaturesCommunityPoiGallery :images="poi.gallery" />
       </section>
 
       <section v-if="poi.schematics?.length" class="space-y-4">
         <h2 class="mb-3 text-xl font-semibold text-neutral-900 dark:text-neutral-50">
           {{ t('community_poi.schematics.title') }}
         </h2>
-        <LazySchematics :schematics="poi.schematics" />
-        <LazyLitematicaHelp />
+        <LazyFeaturesCommunityPoiSchematicList :schematics="poi.schematics" />
+        <LazyFeaturesCommunityPoiLitematicaHelp />
       </section>
 
-      <LazyCollaboration :poi="poi" />
+      <LazyFeaturesCommunityPoiCollaboration :poi="poi" />
     </article>
   </main>
 </template>

--- a/pages/community-poi/index.vue
+++ b/pages/community-poi/index.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { defineAsyncComponent, definePageMeta } from '#imports'
+import { definePageMeta } from '#imports'
 import CommunityPoiGrid from '~/components/features/community-poi/CommunityPoiGrid.vue'
 
-const LazyContribute = defineAsyncComponent(() => import('~/components/features/community-poi/CommunityPoiContributeInfo.vue'))
 
 const { t, locale } = useI18n()
 const site = useSiteConfig()
@@ -67,7 +66,7 @@ useSchemaOrg(() => {
     <CommunityPoiGrid :pois="pois" />
 
     <div class="mt-10">
-      <LazyContribute />
+      <LazyFeaturesCommunityPoiContributeInfo />
     </div>
   </main>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { defineAsyncComponent } from 'vue'
 import Carousel from "~/components/features/home/carousel/Carousel.vue";
 import {definePageMeta} from "#imports";
 
@@ -14,11 +13,6 @@ const { sponsors } = useSponsoring()
 const { data: collective } = useOpenCollective()
 useHomeSeo({ title: t('index.title') })
 
-const LazyServerConcept = defineAsyncComponent(() => import('~/components/features/home/server-concept/ServerConcept.vue'))
-const LazyServerAddresses = defineAsyncComponent(() => import('~/components/features/home/server-addresses/ServerAddresses.vue'))
-const LazySponsoring = defineAsyncComponent(() => import('~/components/features/sponsoring/Sponsoring.vue'))
-const LazyOpenCollective = defineAsyncComponent(() => import('~/components/features/opencollective/OpenCollectiveStats.vue'))
-const LazyFaqSection = defineAsyncComponent(() => import('~/components/features/home/faq/FaqSection.vue'))
 
 </script>
 
@@ -34,23 +28,28 @@ const LazyFaqSection = defineAsyncComponent(() => import('~/components/features/
   <div class="-mx-4 sm:-mx-6 px-0 py-6 md:py-10 md:mx-auto md:max-w-6xl md:px-4 lg:px-8">
     <Carousel :slides="slides" aspect="16/9" :aria-label="t('index.carousel_aria')" />
   </div>
+  <!-- Everything below the carousel is off-screen at load; hydrate-on-visible
+       is what turns the code split into a saving. See tests/architecture/lazy-components.spec.ts -->
   <!-- Server Concept Section -->
-  <LazyServerConcept
+  <LazyFeaturesHomeServerConcept
     v-if="concept"
+    hydrate-on-visible
     :title="concept.title"
     :subtitle="concept.subtitle"
     :points="concept.points || []"
   />
   <!-- Server Connect Section -->
-  <LazyServerAddresses
+  <LazyFeaturesHomeServerAddresses
     v-if="connect"
+    hydrate-on-visible
     :java-address="connect.javaAddress"
     :bedrock-host="connect.bedrockHost"
     :bedrock-port="connect.bedrockPort"
   />
-  <LazySponsoring v-if="sponsors?.length" :sponsors="sponsors" />
-  <LazyOpenCollective
+  <LazyFeaturesSponsoring v-if="sponsors?.length" hydrate-on-visible :sponsors="sponsors" />
+  <LazyFeaturesOpencollectiveOpenCollectiveStats
     v-if="collective"
+    hydrate-on-visible
     :total-raised="collective.totalRaised"
     :goal="collective.goal"
     :contributors="collective.contributors"
@@ -58,5 +57,5 @@ const LazyFaqSection = defineAsyncComponent(() => import('~/components/features/
     :link="collective.link"
     :updated-at="collective.updatedAt"
   />
-  <LazyFaqSection />
+  <LazyFeaturesHomeFaqSection hydrate-on-visible />
 </template>

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 354,
+  "eslintErrors": 353,
   "eslintWarnings": 48,
   "typeErrors": 30
 }

--- a/tests/architecture/lazy-components.spec.ts
+++ b/tests/architecture/lazy-components.spec.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * A hand-rolled `defineAsyncComponent(() => import('…'))` in a page buys less
+ * than it looks like.
+ *
+ * Vue awaits async components during SSR, so the markup is in the HTML either
+ * way — measured on this page, all five sections render server-side with the
+ * wrapper in place. What changes is the client: each one becomes a separate
+ * chunk that has to arrive before its subtree can hydrate, and Vue hydrates it
+ * as soon as it does. Five extra requests, and not one unit of hydration work
+ * saved.
+ *
+ * Nuxt's `Lazy` prefix produces the same code-splitting and additionally
+ * accepts a hydration strategy — `hydrate-on-visible` and friends — which is
+ * the part that actually defers work. Reaching for the Vue primitive inside a
+ * page skips the mechanism that makes the split worth making.
+ *
+ * Not guarded here: *which* strategy a given section should use, or whether it
+ * should have one at all. `<LazyX v-if="…">` with no strategy is a reasonable
+ * thing to write when the condition is often false, because then the chunk is
+ * never fetched. That is a judgement per call site, not a rule.
+ */
+
+const SOURCE_DIRS = ['pages', 'layouts']
+
+const HAND_ROLLED_ASYNC = /\bdefineAsyncComponent\s*\(/
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue'])) {
+    const relative = relativeToRepo(file)
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      if (HAND_ROLLED_ASYNC.test(line)) found.push(`${relative}:${index + 1}`)
+    })
+  }
+  return found
+}
+
+describe('lazy components in pages', () => {
+  it('recognises the call', () => {
+    // Without this the check could pass by matching nothing at all.
+    expect(HAND_ROLLED_ASYNC.test("const X = defineAsyncComponent(() => import('~/c.vue'))")).toBe(true)
+    // The import of the helper is not a use of it; only the call is.
+    expect(HAND_ROLLED_ASYNC.test("import { computed } from 'vue'")).toBe(false)
+    expect(HAND_ROLLED_ASYNC.test('<LazyFeaturesHomeFaqSection hydrate-on-visible />')).toBe(false)
+  })
+
+  it('pages defer through the Lazy prefix, not the Vue primitive', () => {
+    expect(offenders()).toEqual([])
+  })
+})

--- a/tests/architecture/unused-components.spec.ts
+++ b/tests/architecture/unused-components.spec.ts
@@ -15,9 +15,13 @@ import { collectSourceFiles, relativeToRepo, repoRoot } from '../helpers/sources
  *
  *   1. Auto-imported tag — `<TeamMembers>`, `<team-members>`, `<LazyTeamMembers>`.
  *      Nuxt needs no import statement, so the tag is the only signal.
- *   2. Explicit import by path, often under a different local name:
+ *   2. The same tag carrying Nuxt's directory prefix. `features/home/faq/
+ *      FaqSection.vue` is `<LazyFeaturesHomeFaqSection>` — the file name is a
+ *      suffix of the tag, not the whole of it. Only prefixes actually built
+ *      from that component's own directories count, so a dead `Card.vue`
+ *      cannot be kept alive by an unrelated `<SomeOtherCard>` elsewhere.
+ *   3. Explicit import by path, often under a different local name:
  *      `import UiChip from '~/components/base/Chip.vue'` renders as `<UiChip>`.
- *   3. Dynamic import by path: `defineAsyncComponent(() => import('…/X.vue'))`.
  *   4. Convention, never referenced in any template — see EXEMPT below.
  */
 
@@ -28,8 +32,7 @@ const CONSUMER_DIRS = [
 ]
 
 const ROOT_CONSUMERS = [
-  'app.vue',
-  'error.vue',
+  'app.vue', 'error.vue',
 ]
 
 /**
@@ -41,8 +44,7 @@ const ROOT_CONSUMERS = [
  *                              passed to defineOgImage('TeamMember').
  */
 const EXEMPT = [
-  /^components\/content\/Prose/,
-  /^components\/OgImage\//,
+  /^components\/content\/Prose/, /^components\/OgImage\//,
 ]
 
 function kebab(name: string): string {
@@ -59,12 +61,33 @@ function escape(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+/**
+ * Every prefix Nuxt could put in front of this component's file name, built
+ * from its own directory chain. `features/home/faq/FaqSection.vue` yields
+ * `''`, `Features`, `FeaturesHome`, `FeaturesHomeFaq` — one of which, plus the
+ * file name, is the registered tag. Deriving them per component rather than
+ * accepting any PascalCase prefix is what keeps the check from excusing a dead
+ * component whose name merely ends another one.
+ */
+function directoryPrefixes(componentPath: string): string[] {
+  const segments = relativeToRepo(componentPath)
+    .replace(/^components\//, '')
+    .split('/')
+    .slice(0, -1)
+    .map((segment) => segment.split(/[-_]/).map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(''))
+
+  const prefixes = ['']
+  for (const segment of segments) prefixes.push(prefixes[prefixes.length - 1]! + segment)
+  return prefixes
+}
+
 function isReferenced(componentPath: string, corpus: Map<string, string>): boolean {
   const name = basename(componentPath, '.vue')
   const pathFromComponents = relativeToRepo(componentPath).replace(/^components\//, '')
+  const prefixes = directoryPrefixes(componentPath).map(escape).join('|')
   const patterns = [
-    // Tag, in either spelling, with or without Nuxt's Lazy prefix.
-    new RegExp(`<(?:Lazy)?${escape(name)}[\\s/>]`),
+    // Tag, in either spelling, with or without Nuxt's Lazy and directory prefixes.
+    new RegExp(`<(?:Lazy)?(?:${prefixes})${escape(name)}[\\s/>]`),
     new RegExp(`<(?:lazy-)?${escape(kebab(name))}[\\s/>]`),
     // Imported by path — catches renamed local bindings and async imports.
     new RegExp(`['"\`][^'"\`]*${escape(pathFromComponents)}['"\`]`),
@@ -95,11 +118,19 @@ describe('components', () => {
 
     const autoImported = byName('features/navigation/NavigationBar.vue')
     const renamedImport = byName('base/Chip.vue') //        imported as UiChip
-    const asyncImport = byName('community-poi/CommunityPoiGallery.vue')
+    const prefixedTag = byName('features/home/faq/FaqSection.vue') // <LazyFeaturesHomeFaqSection>
 
     expect(autoImported && isReferenced(autoImported, corpus)).toBe(true)
     expect(renamedImport && isReferenced(renamedImport, corpus)).toBe(true)
-    expect(asyncImport && isReferenced(asyncImport, corpus)).toBe(true)
+    expect(prefixedTag && isReferenced(prefixedTag, corpus)).toBe(true)
+
+    // The prefixes have to come from the component's own path, or the check
+    // stops being able to tell a used component from a dead one.
+    expect(directoryPrefixes(prefixedTag!)).toEqual(['',
+      'Features',
+      'FeaturesHome',
+      'FeaturesHomeFaq'])
+    expect(directoryPrefixes(byName('base/Chip.vue')!)).toEqual(['', 'Base'])
   })
 
   it('are all rendered somewhere', () => {


### PR DESCRIPTION
Implements `ARCH-08`, test-first.

## What the wrapper was buying

Twelve `defineAsyncComponent(() => import('…'))` across four pages — the finding named five, the guard found the rest.

Vue awaits async components during SSR, so the markup ships either way. Measured on the homepage before touching anything, all five sections are fully server-rendered:

```
<section aria-labelledby="server-concept-title" …
<section id="connect" …
<section id="sponsoring" …
<section id="opencollective" …
<section aria-labelledby="faq-heading" …
```

So the wrapper saved no SSR payload. On the client it did the opposite of what the `Lazy` naming suggested: each section became its own chunk that had to arrive before that subtree could hydrate, and Vue hydrated it the moment it did. Five extra requests, zero hydration work deferred.

Nuxt's `Lazy` prefix gives the same code-splitting **and** accepts a hydration strategy. That is the part that actually defers work, and it is unreachable from the Vue primitive.

## Measured, both directions

Homepage SSR output, before vs after — the entire diff is my one added comment and the dev-mode log timestamps:

```
before  121300 bytes   after  122677 bytes
concept 12 → 12   faq 36 → 36   sponsor 28 → 28   collective 34 → 34   bedrock 9 → 9
same six <section> elements, same order
```

The POI detail page, which gets five renames and no strategy change, came back **83114 → 83113 bytes** (one digit of a dev timestamp) with the same seven sections.

What I did *not* measure: client-side hydration timing. The deferral is the documented behaviour of `hydrate-on-visible`, not something I put a number on.

## Where the strategy goes, and where it doesn't

`hydrate-on-visible` on the five homepage sections only — every one sits below the carousel and is off-screen at load.

The other seven get a plain `<Lazy…>` and no strategy, which is behaviour-identical to what they had. That is deliberate: several are behind a `v-if` that is often false (`<LazyFeaturesCommunityPoiCollaboration>`, `<LazyFeaturesBlogSocialMediaShare>`), and there the win is already the chunk never being fetched. Choosing a strategy per section is a judgement call, and the guard says so rather than inventing a rule.

## Fallout worth reading

The change broke `unused-components.spec.ts`, and the break was correct: that test matched `<(?:Lazy)?ComponentName>`, but the auto-import tag for `features/home/faq/FaqSection.vue` is `<LazyFeaturesHomeFaqSection>` — the file name is a *suffix* of the tag, not the whole of it. Twelve components suddenly read as dead.

The fix derives the allowed prefixes from each component's own directory chain (`''`, `Features`, `FeaturesHome`, `FeaturesHomeFaq`) rather than accepting any PascalCase prefix. That distinction matters: a blanket prefix would let an unrelated `<SomeOtherCard>` keep a dead `Card.vue` alive.

Checked adversarially — dropping a throwaway `FaqSectionCard.vue` next to the real `FaqSection.vue`, a name that shares a prefix with a live component, is still reported:

```
+ "components/features/home/faq/FaqSectionCard.vue"
```

## Gates

Suite: 70 tests, 21 files. Build green. Ratchet **down** to 353 (the removed `defineAsyncComponent` imports); baseline drops with the commit.

Refs: `ARCH-08`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s