### PR TITLE
fix(config): drop env fallbacks that never fire in the browser

### DIFF
--- a/components/features/navigation/NavigationBar.vue
+++ b/components/features/navigation/NavigationBar.vue
@@ -24,7 +24,10 @@ const openGroup = ref<string | null>(null);
 const mobileMenuId = 'mobile-menu-panel';
 // Verwende die reaktive i18n-Locale; localePath nutzt automatisch die aktuelle Sprache
 const localePath = useLocalePath();
-const discordUrl = (runtimeConfig.public?.discordUrl as string | undefined) || (process?.env?.NUXT_PUBLIC_DISCORD_URL as string | undefined);
+// NUXT_PUBLIC_DISCORD_URL still overrides this — Nuxt folds it into the same
+// runtimeConfig key. The env fallback that used to follow ran in the browser
+// too, where Vite replaces process.env with `{}`, so it never fired.
+const discordUrl = runtimeConfig.public.discordUrl as string;
 
 type BuiltLink = NavLinkConfig & { path: string }
 type BuiltGroup = NavGroupConfig & { children: BuiltLink[] }

--- a/composables/useBluemap.ts
+++ b/composables/useBluemap.ts
@@ -1,13 +1,14 @@
 // Simple composable to provide the BlueMap URL from runtime config
-// Falls back to environment variable NUXT_PUBLIC_BLUEMAP_URL if present
 // Usage: const bluemapUrl = useBluemapUrl()
+//
+// NUXT_PUBLIC_BLUEMAP_URL still overrides it — that is exactly the variable
+// Nuxt folds into runtimeConfig.public.bluemapUrl, so reading the key covers
+// the env case. The fallback that used to sit here read process.env from code
+// that also runs in the browser, where Vite replaces the expression with `{}`;
+// it could only ever produce undefined. The default lives in nuxt.config.ts.
 export const useBluemapUrl = (): string => {
   const runtimeConfig = useRuntimeConfig();
-  // Prefer runtimeConfig.public but allow an env override as safety net
-  const envUrl = (process?.env?.NUXT_PUBLIC_BLUEMAP_URL as string | undefined);
-  return (runtimeConfig.public?.bluemapUrl as string | undefined)
-    || envUrl
-    || 'https://bluemap.onelitefeather.dev/';
+  return runtimeConfig.public.bluemapUrl as string;
 };
 
 export type BluemapDimension = 'overworld' | 'nether' | 'end'

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 354,
+  "eslintErrors": 353,
   "eslintWarnings": 48,
   "typeErrors": 30
 }

--- a/tests/architecture/client-env-access.spec.ts
+++ b/tests/architecture/client-env-access.spec.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * Code under these directories runs in the browser as well as on the server,
+ * and `process.env` does not survive the trip.
+ *
+ * The Vite client build replaces the expression with an empty object literal.
+ * Read straight out of the shipped bundle:
+ *
+ *     var m={};const f=()=>{ … const n=m?.NUXT_PUBLIC_BLUEMAP_URL; … }
+ *     wt={} … b=r.public?.discordUrl||wt?.NUXT_PUBLIC_DISCORD_URL
+ *
+ * So the lookup is not merely unreliable — it is `undefined` by construction,
+ * every time, and the `?.` that makes it look defensive is what hides that.
+ *
+ * There is nothing to fall back *to*, either. `NUXT_PUBLIC_BLUEMAP_URL` and
+ * `NUXT_PUBLIC_DISCORD_URL` are exactly the environment variables Nuxt already
+ * folds into `runtimeConfig.public.bluemapUrl` / `.discordUrl`, and both keys
+ * carry non-empty defaults in `nuxt.config.ts`. The first operand is therefore
+ * always truthy and the fallback unreachable on the server too.
+ *
+ * `runtimeConfig` is the mechanism that works in both places. Build-time
+ * configuration files and `server/` are a different matter and stay out of
+ * scope — there `process.env` is the correct thing to read.
+ */
+
+const CLIENT_DIRS = ['components',
+  'pages',
+  'layouts',
+  'composables',
+  'utils',
+  'plugins']
+
+/** `process.env.X`, `process?.env?.X`, `process["env"]` — any of the spellings. */
+const PROCESS_ENV = /\bprocess\s*\??\.\s*env\b|\bprocess\s*\??\.\s*\[\s*['"]env['"]/
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(CLIENT_DIRS, ['.vue',
+'.ts',
+'.js'])) {
+    const relative = relativeToRepo(file)
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      if (PROCESS_ENV.test(line)) found.push(`${relative}:${index + 1}`)
+    })
+  }
+  return found
+}
+
+describe('client-side environment access', () => {
+  it('recognises the spellings', () => {
+    // Without this the check could pass by matching nothing at all.
+    expect(PROCESS_ENV.test('const url = process.env.NUXT_PUBLIC_BLUEMAP_URL')).toBe(true)
+    expect(PROCESS_ENV.test('const url = (process?.env?.NUXT_PUBLIC_DISCORD_URL as string)')).toBe(true)
+    // `import.meta.server` and friends are compile-time flags Vite does replace.
+    expect(PROCESS_ENV.test('if (import.meta.server) return')).toBe(false)
+    // The supported mechanism.
+    expect(PROCESS_ENV.test('const config = useRuntimeConfig().public')).toBe(false)
+    // A different `process`-shaped identifier is not the global.
+    expect(PROCESS_ENV.test('const processed = items.map(process)')).toBe(false)
+  })
+
+  it('no browser-bound module reads process.env', () => {
+    expect(offenders()).toEqual([])
+  })
+})

--- a/tests/architecture/client-env-access.spec.ts
+++ b/tests/architecture/client-env-access.spec.ts
@@ -36,6 +36,12 @@ const CLIENT_DIRS = ['components',
 /** `process.env.X`, `process?.env?.X`, `process["env"]` — any of the spellings. */
 const PROCESS_ENV = /\bprocess\s*\??\.\s*env\b|\bprocess\s*\??\.\s*\[\s*['"]env['"]/
 
+/**
+ * A comment naming the thing is not a use of it — and this rule is one whose
+ * fix wants explaining at the call site, so the explanation must not trip it.
+ */
+const COMMENT_LINE = /^\s*(?:\/\/|\/\*|\*|<!--)/
+
 function offenders(): string[] {
   const found: string[] = []
   for (const file of collectSourceFiles(CLIENT_DIRS, ['.vue',
@@ -44,6 +50,7 @@ function offenders(): string[] {
     const relative = relativeToRepo(file)
     const text = readFileSync(file, 'utf8')
     text.split('\n').forEach((line, index) => {
+      if (COMMENT_LINE.test(line)) return
       if (PROCESS_ENV.test(line)) found.push(`${relative}:${index + 1}`)
     })
   }
@@ -61,6 +68,12 @@ describe('client-side environment access', () => {
     expect(PROCESS_ENV.test('const config = useRuntimeConfig().public')).toBe(false)
     // A different `process`-shaped identifier is not the global.
     expect(PROCESS_ENV.test('const processed = items.map(process)')).toBe(false)
+
+    // Comments are skipped, but only comments — a trailing one must not
+    // launder the code in front of it.
+    expect(COMMENT_LINE.test('// the former fallback read process.env')).toBe(true)
+    expect(COMMENT_LINE.test(' * it could only ever produce undefined')).toBe(true)
+    expect(COMMENT_LINE.test('const url = process.env.X // still a read')).toBe(false)
   })
 
   it('no browser-bound module reads process.env', () => {


### PR DESCRIPTION
Implements `ARCH-05`, test-first.

## Dead by construction, not merely unreliable

Two modules that also run in the browser reached for `process.env`:

```ts
composables/useBluemap.ts   const envUrl = process?.env?.NUXT_PUBLIC_BLUEMAP_URL
NavigationBar.vue           runtimeConfig.public?.discordUrl || process?.env?.NUXT_PUBLIC_DISCORD_URL
```

Read straight out of the shipped client bundle, before the change:

```js
var m={};const f=()=>{ … const n=m?.NUXT_PUBLIC_BLUEMAP_URL; … }
wt={} … b=r.public?.discordUrl||wt?.NUXT_PUBLIC_DISCORD_URL
```

Vite replaces `process.env` with an **empty object literal**. So these were not "usually undefined" — they were `undefined` every time, and the `?.` that makes the line look defensive is exactly what hid it. After the change both identifiers are gone from `.output/public/_nuxt/` entirely.

They were redundant on the server too: `NUXT_PUBLIC_BLUEMAP_URL` and `NUXT_PUBLIC_DISCORD_URL` are precisely the variables Nuxt folds into `runtimeConfig.public.bluemapUrl` / `.discordUrl`, and both keys carry non-empty defaults, so the first operand was always truthy.

## Both paths measured

Dev server with the variables set, **after** removing the fallbacks:

```
NUXT_PUBLIC_BLUEMAP_URL=https://map.example.test/     → <iframe src="https://map.example.test/">
NUXT_PUBLIC_DISCORD_URL=https://discord.example.test/x → href="https://discord.example.test/x"
```

And without them, the configured defaults:

```
https://bluemap.onelitefeather.dev/   https://1lf.link/discord
```

The override reaching the page with no fallback present is what proves `runtimeConfig` was carrying it all along.

`useBluemapUrl` also loses its hardcoded `'https://bluemap.onelitefeather.dev/'` tail, which was a third copy of a value `nuxt.config.ts` already declares twice. The default belongs in the config.

## The guard

Flags any `process.env` spelling under `components`, `pages`, `layouts`, `composables`, `utils` and `plugins`. Config files and `server/` stay out of scope — there it is the correct thing to read.

It skips comment lines, which is not a convenience: this is a rule whose fix wants explaining at the call site, and the first run failed on my own explanatory comments. The self-test pins that a *trailing* comment cannot launder the code in front of it.

## Gates

Suite: 74 tests, 23 files. Build green. Ratchet down to 353. Note that #238 lowers it to the same number by a different route; the two set an identical value, so whichever lands first the other still applies.

Refs: `ARCH-05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s