### PR TITLE
chore(i18n): remove orphaned translation keys

### DIFF
--- a/components/features/blog/SocialMediaShare.vue
+++ b/components/features/blog/SocialMediaShare.vue
@@ -3,7 +3,7 @@ import { computed, ref, onMounted } from '#imports'
 import IconFa from '~/components/base/icons/IconFa.vue'
 import { useAnalytics } from '~/composables/useAnalytics'
 
-type PlatformKey = 'facebook' | 'twitter' | 'linkedin' | 'whatsapp' | 'telegram' | 'bluesky' | 'mastodon' | 'reddit' | 'email' | 'copy' | 'native'
+type PlatformKey = 'facebook' | 'twitter' | 'linkedin' | 'whatsapp' | 'telegram' | 'bluesky' | 'reddit' | 'email' | 'copy' | 'native'
 
 const props = defineProps({
   url: {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -16,7 +16,6 @@
     "change_language": "Sprache ändern",
     "more": "Mehr",
     "status": "Status",
-    "roadmap": "Roadmap",
     "community_poi": "Community-POIs"
   },
   "carousel": {
@@ -39,7 +38,6 @@
   "layouts": {
     "title": "Titel"
   },
-  "TDB": "Zu erledigen",
   "server": {
     "connect": {
       "title": "Mit dem Server verbinden",
@@ -81,16 +79,8 @@
   },
   "team": {
     "title": "Team",
-    "subtitle": "Lerne die Menschen hinter OneLiteFeather kennen.",
     "profile_title_fallback": "Team",
     "profile_description_fallback": "Teammitglied-Profil bei OneLiteFeather.",
-    "search_label": "Team durchsuchen",
-    "search_placeholder": "Name suchen…",
-    "filter_role": "Rolle",
-    "filter_role_all": "Alle",
-    "limit_label": "Anzahl",
-    "scroll_area_aria": "Horizontale Teamliste zum Scrollen",
-    "list_label": "Teammitglieder",
     "no_results": "Keine Ergebnisse gefunden",
     "card_aria": "Profil von {name}, {role}",
     "avatar_alt": "Avatar von {name}",
@@ -123,13 +113,6 @@
       "section_subtitle": "Antworten zu Ablauf, Anforderungen und dem Lite-Rang."
     }
   },
-  "timeline": {
-    "aria_label": "Zeitachse",
-    "show_all": "Alle anzeigen",
-    "show_all_aria": "Alle Ereignisse der Zeitachse anzeigen",
-    "more": "Mehr",
-    "more_aria": "Mehr zu {title}"
-  },
   "sponsor": {
     "title": "Sponsoring",
     "subtitle": "Partner, die unsere Infrastruktur ermöglichen",
@@ -156,21 +139,9 @@
     "brand": "OneLiteFeather",
     "description": "Ein Minecraft‑Netzwerk mit Fokus auf Community und Entwicklung",
     "copyright": "© {year} OneLiteFeather. Alle Rechte vorbehalten.",
-    "social_media": "Social Media",
-    "legal": "Rechtliches",
-    "github": "GitHub",
-    "github_aria": "GitHub (öffnet in einem neuen Tab)",
-    "opencollective": "OpenCollective",
-    "opencollective_aria": "OpenCollective (öffnet in einem neuen Tab)",
-    "imprint": "Impressum",
-    "privacy_policy": "Datenschutz",
-    "all_rights_reserved": "Alle Rechte vorbehalten",
-    "made_with_love": "Mit Liebe erstellt vom OneLiteFeather Team und Mitwirkenden",
-    "love": "Liebe",
     "aria_label": "Website‑Fußzeile",
     "services": {
       "title": "Dienste",
-      "minecraft": "Minecraft Server",
       "blogging": "Blog",
       "status": "Status",
       "github": "GitHub"
@@ -178,8 +149,7 @@
     "organization": {
       "title": "Organisation",
       "about": "Über uns",
-      "contact": "Kontakt",
-      "careers": "Karriere"
+      "contact": "Kontakt"
     },
     "version": "Version {version}",
     "social": {
@@ -216,7 +186,6 @@
     "share_on_whatsapp": "Auf WhatsApp teilen",
     "share_on_telegram": "Auf Telegram teilen",
     "share_on_bluesky": "Auf Bluesky teilen",
-    "share_on_mastodon": "Auf Mastodon teilen",
     "share_on_reddit": "Auf Reddit teilen",
     "share_by_email": "Per E-Mail teilen",
     "share_native": "Teilen…",
@@ -295,8 +264,6 @@
       "aria": "BlueMap-Link mit Koordinaten",
       "open": "Auf BlueMap öffnen",
       "link_aria": "{title} auf der BlueMap öffnen (neuer Tab)",
-      "show_preview": "Mini-Vorschau einblenden",
-      "hide_preview": "Mini-Vorschau ausblenden",
       "iframe_title": "BlueMap-Vorschau für {title}",
       "embed_note": "Vorschau geladen von {host}. Für volle Funktionen die externe Seite öffnen."
     },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -16,7 +16,6 @@
     "change_language": "Change language",
     "more": "More",
     "status": "Status",
-    "roadmap": "Roadmap",
     "community_poi": "Community POIs"
   },
   "carousel": {
@@ -39,7 +38,6 @@
   "layouts": {
     "title": "Title"
   },
-  "TDB": "To Do",
   "server": {
     "connect": {
       "title": "Connect to the server",
@@ -81,16 +79,8 @@
   },
   "team": {
     "title": "Team",
-    "subtitle": "Meet the people behind OneLiteFeather.",
     "profile_title_fallback": "Team",
     "profile_description_fallback": "Team member profile on OneLiteFeather.",
-    "search_label": "Search team",
-    "search_placeholder": "Search name…",
-    "filter_role": "Role",
-    "filter_role_all": "All",
-    "limit_label": "Count",
-    "scroll_area_aria": "Horizontal scrollable team list",
-    "list_label": "Team members",
     "no_results": "No results found",
     "card_aria": "Profile of {name}, {role}",
     "avatar_alt": "Avatar of {name}",
@@ -123,13 +113,6 @@
       "section_subtitle": "Answers on the process, requirements, and the Lite rank."
     }
   },
-  "timeline": {
-    "aria_label": "Timeline",
-    "show_all": "Show all",
-    "show_all_aria": "Show all timeline events",
-    "more": "More",
-    "more_aria": "More about {title}"
-  },
   "sponsor": {
     "title": "Sponsoring",
     "subtitle": "Partners that power our infrastructure",
@@ -156,21 +139,9 @@
     "brand": "OneLiteFeather",
     "description": "A Minecraft network focused on community and development",
     "copyright": "© {year} OneLiteFeather. All rights reserved.",
-    "social_media": "Social Media",
-    "legal": "Legal",
-    "github": "GitHub",
-    "github_aria": "GitHub (opens in a new tab)",
-    "opencollective": "OpenCollective",
-    "opencollective_aria": "OpenCollective (opens in a new tab)",
-    "imprint": "Imprint",
-    "privacy_policy": "Privacy Policy",
-    "all_rights_reserved": "All rights reserved",
-    "made_with_love": "Made with love by the OneLiteFeather Team and contributors",
-    "love": "love",
     "aria_label": "Website footer",
     "services": {
       "title": "Services",
-      "minecraft": "Minecraft Server",
       "blogging": "Blog",
       "status": "Status",
       "github": "GitHub"
@@ -178,8 +149,7 @@
     "organization": {
       "title": "Organization",
       "about": "About us",
-      "contact": "Contact",
-      "careers": "Careers"
+      "contact": "Contact"
     },
     "version": "Version {version}",
     "social": {
@@ -216,7 +186,6 @@
     "share_on_whatsapp": "Share on WhatsApp",
     "share_on_telegram": "Share on Telegram",
     "share_on_bluesky": "Share on Bluesky",
-    "share_on_mastodon": "Share on Mastodon",
     "share_on_reddit": "Share on Reddit",
     "share_by_email": "Share by Email",
     "share_native": "Share…",
@@ -295,8 +264,6 @@
       "aria": "BlueMap link with coordinates",
       "open": "Open on BlueMap",
       "link_aria": "Open {title} on BlueMap (new tab)",
-      "show_preview": "Show mini preview",
-      "hide_preview": "Hide mini preview",
       "iframe_title": "BlueMap preview for {title}",
       "embed_note": "Preview loaded from {host}. Open the external site for full functionality."
     },

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 353,
+  "eslintErrors": 352,
   "eslintWarnings": 48,
   "typeErrors": 30
 }

--- a/tests/i18n/unused-keys.spec.ts
+++ b/tests/i18n/unused-keys.spec.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, repoRoot } from '../helpers/sources'
+
+/**
+ * The complement of `message-keys.spec.ts`. That one asks whether every key a
+ * call site uses exists; this one asks whether every key that exists is used.
+ *
+ * A stale message is not inert. Translators are asked to keep it current, it
+ * turns up when someone greps for wording that is live somewhere else, and a
+ * near-duplicate is the sort of thing that gets picked by mistake — this file
+ * carried `footer.imprint`, `footer.legal` and `footer.privacy_policy` while
+ * the footer actually renders `footer.terms` and `footer.privacy`.
+ *
+ * Dynamically built keys are the reason a check like this needs care. Six
+ * prefixes are assembled at runtime — `t(`team.ranks.${rank}`)` and friends —
+ * and every key beneath them would read as unused. They are detected from the
+ * source rather than listed by hand, so adding a seventh does not silently
+ * turn part of the locale file into a blind spot.
+ */
+
+const CORPUS_DIRS = ['components',
+  'pages',
+  'layouts',
+  'composables',
+  'utils',
+  'plugins',
+  'server',
+  'types']
+const ROOT_FILES = ['app.vue',
+  'error.vue',
+  'nuxt.config.ts']
+const LOCALES = ['de', 'en']
+
+/** ``t(`community_poi.status.${poi.status}`)`` — the part before the hole. */
+const DYNAMIC_PREFIX = /[`'"]([a-z][\w.]*)\.\$\{/g
+
+type Messages = Record<string, unknown>
+
+function flatten(messages: Messages, prefix = ''): Record<string, string> {
+  const flat: Record<string, string> = {}
+  for (const [key, value] of Object.entries(messages)) {
+    const path = `${prefix}${key}`
+    if (value !== null && typeof value === 'object') Object.assign(flat, flatten(value as Messages, `${path}.`))
+    else flat[path] = String(value)
+  }
+  return flat
+}
+
+function locale(code: string): Record<string, string> {
+  return flatten(JSON.parse(readFileSync(`${repoRoot}/i18n/locales/${code}.json`, 'utf8')))
+}
+
+function corpus(): string {
+  const files = collectSourceFiles(CORPUS_DIRS, ['.vue',
+'.ts',
+'.js'])
+    .concat(ROOT_FILES.map((file) => `${repoRoot}/${file}`))
+  return files.map((file) => readFileSync(file, 'utf8')).join('\n')
+}
+
+describe('translation keys', () => {
+  const text = corpus()
+  const dynamicPrefixes = [...new Set([...text.matchAll(DYNAMIC_PREFIX)].map(([, prefix]) => prefix!))]
+
+  it('reads the locale files and the call sites', () => {
+    // Without this, an empty corpus would read as "everything is used".
+    expect(Object.keys(locale('de')).length).toBeGreaterThan(200)
+    expect(text.length).toBeGreaterThan(100_000)
+    expect(dynamicPrefixes).toContain('team.ranks')
+
+    expect(flatten({ a: { b: 'x' }, c: 1 })).toEqual({ 'a.b': 'x', c: '1' })
+  })
+
+  it('are declared in both locales', () => {
+    expect(Object.keys(locale('en')).sort()).toEqual(Object.keys(locale('de')).sort())
+  })
+
+  it('are all referenced somewhere', () => {
+    const orphans = Object.keys(locale('de'))
+      .filter((key) => !dynamicPrefixes.some((prefix) => key.startsWith(`${prefix}.`)))
+      .filter((key) => !text.includes(key))
+    expect(orphans).toEqual([])
+  })
+
+  it.each(LOCALES)('%s has no placeholder entries left', (code) => {
+    const suspicious = Object.entries(locale(code))
+      .filter(([key, value]) => /^(TDB|TODO|TBD|FIXME)$/i.test(key) || /^(TODO|TBD|FIXME)\b/i.test(value))
+      .map(([key]) => key)
+    expect(suspicious).toEqual([])
+  })
+})

--- a/tests/i18n/unused-keys.spec.ts
+++ b/tests/i18n/unused-keys.spec.ts
@@ -32,16 +32,30 @@ const ROOT_FILES = ['app.vue',
   'nuxt.config.ts']
 const LOCALES = ['de', 'en']
 
+/** Keys and values left over from scaffolding, e.g. `"TDB": "Zu erledigen"`. */
+const PLACEHOLDER_KEY = /^(TDB|TODO|TBD|FIXME)$/i
+const PLACEHOLDER_VALUE = /^(TODO|TBD|FIXME)\b/i
+
 /** ``t(`community_poi.status.${poi.status}`)`` — the part before the hole. */
 const DYNAMIC_PREFIX = /[`'"]([a-z][\w.]*)\.\$\{/g
 
 type Messages = Record<string, unknown>
 
+/**
+ * Objects are namespaces and get descended into; arrays are leaves and do not.
+ *
+ * A message array is read whole — `tm('community_poi.litematica.faq.entries')`
+ * — and its elements are consumed by position, so `entries.0.q` is a path no
+ * call site will ever contain. Descending into it manufactures 22 orphans that
+ * are nothing of the sort, which is exactly what the first version of this
+ * file did.
+ */
 function flatten(messages: Messages, prefix = ''): Record<string, string> {
   const flat: Record<string, string> = {}
   for (const [key, value] of Object.entries(messages)) {
     const path = `${prefix}${key}`
-    if (value !== null && typeof value === 'object') Object.assign(flat, flatten(value as Messages, `${path}.`))
+    const isNamespace = value !== null && typeof value === 'object' && !Array.isArray(value)
+    if (isNamespace) Object.assign(flat, flatten(value as Messages, `${path}.`))
     else flat[path] = String(value)
   }
   return flat
@@ -61,7 +75,8 @@ function corpus(): string {
 
 describe('translation keys', () => {
   const text = corpus()
-  const dynamicPrefixes = [...new Set([...text.matchAll(DYNAMIC_PREFIX)].map(([, prefix]) => prefix!))]
+  const prefixMatches = [...text.matchAll(DYNAMIC_PREFIX)].map(([, prefix]) => prefix!)
+  const dynamicPrefixes = [...new Set(prefixMatches)]
 
   it('reads the locale files and the call sites', () => {
     // Without this, an empty corpus would read as "everything is used".
@@ -70,6 +85,8 @@ describe('translation keys', () => {
     expect(dynamicPrefixes).toContain('team.ranks')
 
     expect(flatten({ a: { b: 'x' }, c: 1 })).toEqual({ 'a.b': 'x', c: '1' })
+    // An array is one key, not one key per element — see flatten's note.
+    expect(Object.keys(flatten({ faq: { entries: [{ q: 'a' }, { q: 'b' }] } }))).toEqual(['faq.entries'])
   })
 
   it('are declared in both locales', () => {
@@ -85,7 +102,7 @@ describe('translation keys', () => {
 
   it.each(LOCALES)('%s has no placeholder entries left', (code) => {
     const suspicious = Object.entries(locale(code))
-      .filter(([key, value]) => /^(TDB|TODO|TBD|FIXME)$/i.test(key) || /^(TODO|TBD|FIXME)\b/i.test(value))
+      .filter(([key, value]) => PLACEHOLDER_KEY.test(key) || PLACEHOLDER_VALUE.test(value))
       .map(([key]) => key)
     expect(suspicious).toEqual([])
   })


### PR DESCRIPTION
Implements `I18N-10`, test-first. The finding named five keys; the guard found **31**, in both locales, which stay perfectly in sync at 274 → 243.

## What they were

| group | why |
|---|---|
| `timeline.*` (5) | the timeline feature was removed as dead code; the strings stayed |
| `team.filter_*`, `team.search_*`, `team.subtitle`, … (7) | same, from removed team components |
| `footer.*` (10) | superseded variants — see below |
| `community_poi.bluemap.{show,hide}_preview` | a preview toggle that no longer exists |
| `TDB`, `navigation.roadmap`, `footer.organization.careers`, `footer.services.minecraft`, `article.share_on_mastodon` | the five from the finding |

The footer group is the one that shows why this is worth a check rather than a comment. The file carried `footer.imprint`, `footer.legal` and `footer.privacy_policy` while the footer actually renders `footer.terms` and `footer.privacy`. Three plausible-looking near-duplicates sitting next to the two real ones is a trap for whoever edits that wording next.

`article.share_on_mastodon` had a matching loose end in code: `SocialMediaShare.vue` listed `'mastodon'` in its `PlatformKey` union while the `platforms` array never contained it. Removed with the key.

## Said plainly

Three of the 31 — `navigation.roadmap`, `footer.organization.careers`, `footer.services.minecraft` — read like strings staged for pages that do not exist yet, rather than leftovers. I removed them anyway, because an unreferenced key is indistinguishable from an abandoned one and git history keeps them a `git show` away. If any of those pages is actually in flight, that is the one call worth reversing here.

## The bug the test found in itself

The first run reported 22 extra orphans under `community_poi.litematica.faq.entries.*`. All false: that subtree is a **JSON array**, read whole via `tm('community_poi.litematica.faq.entries')`, with elements consumed by position. `typeof [] === 'object'`, so the flattener descended into it and manufactured paths like `entries.0.q` that no call site could ever contain.

Arrays are now leaves, and a self-test pins it:

```ts
expect(Object.keys(flatten({ faq: { entries: [{ q: 'a' }, { q: 'b' }] } }))).toEqual(['faq.entries'])
```

The six runtime-assembled prefixes (`team.ranks`, `community_poi.status`, …) are detected from the source rather than hand-listed, so a seventh does not quietly turn part of the locale file into a blind spot.

## Verified rendered

Dev server, after the deletions — the footer's legal links, which is where the near-duplicates were:

```
/de   Datenschutz   Impressum
/en   Privacy       Imprint
```

`message-keys.spec.ts` independently confirms every `t()` argument in the tree still resolves in both locales, which is a stronger check than any single page render.

## Gates

Suite: 81 tests, 25 files. Build green. Ratchet down to 352.

Refs: `I18N-10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s