### PR TITLE
fix(a11y): stop pages from opening a second main landmark

### DIFF
--- a/pages/community-poi/[...slug].vue
+++ b/pages/community-poi/[...slug].vue
@@ -106,7 +106,7 @@ const progressSectionClass = [
 </script>
 
 <template>
-  <main class="container mx-auto max-w-screen-lg px-4 py-6 md:px-6 md:py-10">
+  <div class="container mx-auto max-w-screen-lg px-4 py-6 md:px-6 md:py-10">
     <article v-if="poi" class="space-y-8">
       <header class="space-y-4">
         <p class="text-sm">
@@ -180,5 +180,5 @@ const progressSectionClass = [
 
       <LazyFeaturesCommunityPoiCollaboration :poi="poi" />
     </article>
-  </main>
+  </div>
 </template>

--- a/pages/community-poi/index.vue
+++ b/pages/community-poi/index.vue
@@ -48,7 +48,7 @@ useSchemaOrg(() => {
 </script>
 
 <template>
-  <main class="container mx-auto max-w-screen-xl px-4 py-8 md:px-6 md:py-12">
+  <div class="container mx-auto max-w-screen-xl px-4 py-8 md:px-6 md:py-12">
     <header class="mb-8 max-w-3xl">
       <h1
         class="text-3xl font-bold tracking-tight text-neutral-900 dark:text-neutral-50 md:text-4xl"
@@ -68,5 +68,5 @@ useSchemaOrg(() => {
     <div class="mt-10">
       <LazyFeaturesCommunityPoiContributeInfo />
     </div>
-  </main>
+  </div>
 </template>

--- a/pages/team/[slug].vue
+++ b/pages/team/[slug].vue
@@ -133,7 +133,7 @@ if (member.value) {
 </script>
 
 <template>
-  <main class="mx-auto max-w-4xl px-4 py-10">
+  <div class="mx-auto max-w-4xl px-4 py-10">
     <NuxtLink
       :to="`/${locale}/team`"
       class="text-sm text-brand-primary dark:text-brand-primary/80 hover:underline"
@@ -201,5 +201,5 @@ if (member.value) {
     <div v-else class="mt-10 text-center text-gray-700 dark:text-gray-300">
       <p>{{ $t('team.profile_not_found') }}</p>
     </div>
-  </main>
+  </div>
 </template>

--- a/pages/team/index.vue
+++ b/pages/team/index.vue
@@ -52,7 +52,7 @@ useSchemaOrg(() => {
 </script>
 
 <template>
-  <main class="mx-auto max-w-6xl px-4 py-10 md:py-14">
+  <div class="mx-auto max-w-6xl px-4 py-10 md:py-14">
     <header class="mb-8 text-center">
       <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
         {{ t('team.index.title') }}
@@ -76,5 +76,5 @@ useSchemaOrg(() => {
     </p>
 
     <TeamFaqSection />
-  </main>
+  </div>
 </template>

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 353,
+  "eslintErrors": 352,
   "eslintWarnings": 48,
   "typeErrors": 30
 }

--- a/tests/a11y/landmarks.spec.ts
+++ b/tests/a11y/landmarks.spec.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo, repoRoot } from '../helpers/sources'
+
+/**
+ * `layouts/default.vue` wraps the page slot in `<main id="main-content">`, and
+ * it is the only layout in the repository. A page that opens its own `<main>`
+ * therefore nests one inside the other — not a risk, a certainty.
+ *
+ * Measured on the running server before the change:
+ *
+ *   /de/team              <main> × 2
+ *   /de/team/themeinerlp  <main> × 2
+ *   /de/community-poi     <main> × 2
+ *   /de/community-poi/…   <main> × 2
+ *   /de/blog              <main> × 1   ← the correct shape
+ *
+ * HTML permits exactly one non-hidden `main` per document. Two means a
+ * landmark rotor lists two "main" regions with nothing to tell them apart, and
+ * the skip link — which targets `#main-content`, the outer one — drops the
+ * user above a landmark boundary rather than at the content.
+ *
+ * The rule is one-way: pages must not open a `main`, because the layout
+ * already did. Nothing here stops a second layout from being added with a
+ * second `main`; the first assertion at least fails loudly if the one layout
+ * this assumes ever stops providing one.
+ */
+
+const PAGE_DIRS = ['pages']
+const OPENS_MAIN = /<main[\s>]/
+
+function pagesOpeningMain(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(PAGE_DIRS, ['.vue'])) {
+    const relative = relativeToRepo(file)
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      if (OPENS_MAIN.test(line)) found.push(`${relative}:${index + 1}`)
+    })
+  }
+  return found
+}
+
+describe('main landmark', () => {
+  it('is provided exactly once by the layout', () => {
+    // The rule below only holds because of this. If the layout stops opening a
+    // main, removing it from pages would leave the document without one.
+    const layout = readFileSync(`${repoRoot}/layouts/default.vue`, 'utf8')
+    expect(layout.match(/<main[\s>]/g)).toHaveLength(1)
+    expect(layout).toContain('id="main-content"')
+
+    // Without this the page check could pass by matching nothing at all.
+    expect(OPENS_MAIN.test('  <main class="mx-auto max-w-6xl">')).toBe(true)
+    expect(OPENS_MAIN.test('  <main>')).toBe(true)
+    expect(OPENS_MAIN.test('  </main>')).toBe(false)
+    // A component whose name merely starts the same way is not the element.
+    expect(OPENS_MAIN.test('  <MainContent />')).toBe(false)
+  })
+
+  it('is not opened a second time by a page', () => {
+    expect(pagesOpeningMain()).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `A11Y-11`, test-first. The finding named the two team pages; the guard found **four** — both community-poi pages have the same shape.

## Measured, before and after

`layouts/default.vue` wraps the page slot in `<main id="main-content">`, and it is the **only** layout in the repository, so a page that opens its own `main` nests one inside the other by construction. Counted in the server-rendered HTML:

```
                        before   after
/de/team                  2        1
/de/team/themeinerlp      2        1
/de/community-poi         2        1
/de/community-poi/…       2        1
/de/blog                  1        1   ← already the correct shape
```

`id="main-content"` — the skip link's target — is present exactly once throughout, before and after.

## Why it matters beyond the spec

HTML permits one non-hidden `main` per document, but the concrete cost is the skip link. It targets the **outer** `main`, so a keyboard user who takes it lands above a landmark boundary rather than at the content, and a landmark rotor offers two "main" regions with nothing to distinguish them.

## The change is smaller than it sounds

All four elements carried nothing but layout classes:

```
<main class="mx-auto max-w-6xl px-4 py-10 md:py-14">
<main class="container mx-auto max-w-screen-xl px-4 py-8 md:px-6 md:py-12">
```

They are containers, not landmarks. Each becomes a `<div>` with its class list byte-identical, so the rendered layout is unchanged — which the counts above bear out: only the tag name moved.

## The guard

Pages must not open a `main`, because the layout already did. The rule is one-directional and depends on the layout holding up its end, so the first assertion checks exactly that — `layouts/default.vue` opens one `main` and it carries `id="main-content"`. If that ever stops being true, this test fails rather than quietly permitting a document with no landmark at all.

Stated in the file and not guarded: nothing here stops a *second* layout from being added with a second `main`.

## Gates

Suite: 78 tests, 24 files. Build green. Ratchet down to 352.

Refs: `A11Y-11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s