### PR TITLE
perf(content): project the blog overview query instead of SELECT *

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 353,
+  "eslintErrors": 352,
   "eslintWarnings": 48,
   "typeErrors": 30
 }

--- a/tests/content/blog-list-projection.spec.ts
+++ b/tests/content/blog-list-projection.spec.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * `listBlogArticles` feeds one screen: the blog overview, which renders a
+ * headline card and a grid of teasers. Queried without a projection,
+ * @nuxt/content builds `SELECT *` and every row arrives with its `body` — the
+ * full minimark AST of the article — which is then serialised into the SSR
+ * payload so the client can hydrate a list that never displays it.
+ *
+ * Narrowing the query is the fix, and narrowing is also how it breaks: drop a
+ * column a card reads and that card renders an empty slot, silently, on a page
+ * nobody type-checks between the query and the template.
+ *
+ * So this does not merely assert that a projection exists. It reads the fields
+ * the overview actually touches out of its own source and requires the
+ * projection to cover them — the two ends of the contract, compared.
+ */
+
+const ADAPTER = 'utils/content/nuxtContentAdapter.ts'
+
+/** The files that consume a row from `listBlogArticles`. */
+const CONSUMERS = ['components/features/blog/page/card/ArticleCard.vue',
+  'components/features/blog/page/top1/Top1.vue',
+  'pages/blog/index.vue',
+  'composables/useBlogContent.ts']
+
+/** The names an article row goes by in those files. */
+const ROW_IDENTIFIERS = ['blogArticle',
+  'entry',
+  'article']
+
+const SELECT_CALL = /listBlogArticles\([\s\S]*?\.select\(([^)]*)\)/
+const QUOTED = /'([a-zA-Z][\w]*)'/g
+
+function read(file: string): string {
+  return readFileSync(`${repoRoot}/${file}`, 'utf8')
+}
+
+/** Field names the projection asks for. */
+function projectedFields(): string[] {
+  const call = SELECT_CALL.exec(read(ADAPTER))
+  if (!call) return []
+  return [...call[1]!.matchAll(QUOTED)].map(([, field]) => field!)
+}
+
+/**
+ * Field names the overview reads off a row.
+ *
+ * No whitespace is tolerated around the dot. An earlier version allowed it and
+ * matched straight through a comment — `"…rendering an empty article.\n  if
+ * (slug.value …"` produced a required field called `if`. A property access has
+ * no spaces in it; a sentence that happens to end in one of these words does.
+ */
+function requiredFields(): string[] {
+  const names = ROW_IDENTIFIERS.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  const access = new RegExp(`\\b(?:${names})[!?]?\\.([a-zA-Z]\\w*)`, 'g')
+  const found = new Set<string>()
+  for (const file of CONSUMERS) {
+    for (const [, field] of read(file).matchAll(access)) found.add(field!)
+  }
+  // Reads that are not row columns.
+  for (const method of ['map',
+'filter',
+'slice',
+'value',
+'length',
+'getTime',
+'sort',
+'push']) {
+    found.delete(method)
+  }
+  return [...found].sort()
+}
+
+describe('blog overview projection', () => {
+  it('finds both ends of the contract', () => {
+    // Without this, an empty projection and an empty field list would agree.
+    expect(projectedFields().length).toBeGreaterThan(5)
+    const required = requiredFields()
+    expect(required).toContain('slug')
+    expect(required).toContain('headerImage')
+    // `releaseDate` is read only by the release-gate helper, never rendered —
+    // exactly the kind of column a projection written from the template alone
+    // would miss.
+    expect(required).toContain('releaseDate')
+    // Prose in a comment is not a property access — see requiredFields.
+    expect(required).not.toContain('if')
+  })
+
+  it('covers every field the overview reads', () => {
+    const projected = new Set(projectedFields())
+    const missing = requiredFields().filter((field) => !projected.has(field))
+    expect(missing).toEqual([])
+  })
+
+  it('does not ship the article body to a list view', () => {
+    expect(projectedFields()).not.toContain('body')
+  })
+})

--- a/tests/content/blog-list-projection.spec.ts
+++ b/tests/content/blog-list-projection.spec.ts
@@ -31,8 +31,30 @@ const ROW_IDENTIFIERS = ['blogArticle',
   'entry',
   'article']
 
-const SELECT_CALL = /listBlogArticles\([\s\S]*?\.select\(([^)]*)\)/
+const SELECT_CALL = /listBlogArticles\([\s\S]*?\.select\(([\s\S]*?)\n\s*\)/
 const QUOTED = /'([a-zA-Z][\w]*)'/g
+
+/**
+ * Columns that reach a template without ever being named there.
+ *
+ * The field scan below looks for `blogArticle.x`, which finds everything a
+ * template *spells out* — and nothing a component receives whole. ArticleCard
+ * hands the entire row to `<ContentRenderer :value="blogArticle" :excerpt>`,
+ * so `excerpt` appears nowhere in its source, and a projection derived from
+ * the scan alone drops it. That is not hypothetical: the first version of this
+ * change did exactly that, the check stayed green, and the excerpt on all
+ * seven cards vanished. It was caught by diffing the rendered page, not here.
+ */
+const WHOLE_ROW_CONSUMERS = [
+  {
+    file: 'components/features/blog/page/card/ArticleCard.vue',
+    /** `<ContentRenderer :value="blogArticle" :excerpt="true">` */
+    hands_over: /<ContentRenderer[^>]*:value="blogArticle"[^>]*:excerpt="true"/,
+    // `excerpt` is what it renders; `id` becomes the data-content-id attribute
+    // and its absence changes the emitted markup.
+    requires: ['excerpt', 'id']
+  }
+]
 
 function read(file: string): string {
   return readFileSync(`${repoRoot}/${file}`, 'utf8')
@@ -92,6 +114,19 @@ describe('blog overview projection', () => {
   it('covers every field the overview reads', () => {
     const projected = new Set(projectedFields())
     const missing = requiredFields().filter((field) => !projected.has(field))
+    expect(missing).toEqual([])
+  })
+
+  it('covers the columns whole-row consumers read without naming them', () => {
+    const projected = new Set(projectedFields())
+    type Consumer = typeof WHOLE_ROW_CONSUMERS[number]
+    const stillHandsOver = (c: Consumer) => c.hands_over.test(read(c.file))
+    const checked = WHOLE_ROW_CONSUMERS.filter(stillHandsOver)
+
+    // If the pass-through is refactored away the entry is stale, not satisfied.
+    expect(checked).toHaveLength(WHOLE_ROW_CONSUMERS.length)
+
+    const missing = checked.flatMap((consumer) => consumer.requires.filter((field) => !projected.has(field)).map((field) => `${consumer.file} needs ${field}`))
     expect(missing).toEqual([])
   })
 

--- a/utils/content/nuxtContentAdapter.ts
+++ b/utils/content/nuxtContentAdapter.ts
@@ -35,8 +35,37 @@ const communityPoiKey = (locale: Locale) => `community_poi_${locale}` as 'commun
  */
 export function createNuxtContentAdapter(): ContentRepository {
   return {
+    // Projected, not `SELECT *`. This feeds one screen — the overview's
+    // headline card and teaser grid — and without a projection every row
+    // carries `body`, the article's full minimark AST, all the way into the
+    // SSR payload.
+    //
+    // `excerpt` rather than `body` is the load-bearing choice. ArticleCard
+    // renders `<ContentRenderer :value="blogArticle" :excerpt="true">`, which
+    // needs a parsed tree — but @nuxt/content stores the excerpt as its own
+    // column, so the card gets what it draws and nothing else.
+    //
+    // `releaseDate` is in the list but on no card: the release gate in
+    // useBlogContent reads it. Trimming this to what the templates show would
+    // publish unreleased articles. The contract is asserted in
+    // tests/content/blog-list-projection.spec.ts.
     listBlogArticles(locale) {
       return queryCollection(blogKey(locale))
+        .select(
+          // ContentRenderer emits it as data-content-id; without it the
+          // rendered excerpt is identical but loses that attribute.
+          'id',
+          'slug',
+          'title',
+          'alternativeTitle',
+          'description',
+          'excerpt',
+          'headerImage',
+          'headerImageAlt',
+          'pubDate',
+          'releaseDate',
+          'tags'
+        )
         .order('pubDate', 'DESC')
         .all() as Promise<BlogArticle[]>
     },


### PR DESCRIPTION
Implements `PERF-04`, test-first.

## Measured

`listBlogArticles` had no projection, so @nuxt/content built `SELECT *` and every row arrived with `body` — the article's full minimark AST — which was then serialised into the SSR payload for a list that never renders it. Dev server, `/de/blog`:

| | before | after |
|---|---|---|
| `__NUXT_DATA__` | 127 624 B | 11 619 B | **−90.9 %** |
| whole page | 222 961 B | 107 806 B | −51.6 % |
| `"body"` in payload | 8 | 0 | |

**The visible markup is byte-identical**, verified by stripping every `<script>` and comparing the remainder. `/en/blog` likewise renders its six excerpts with no body in the payload.

## The part the finding got wrong, and how I found out

The audit says only the excerpt is rendered, so the body can go. Half right — the excerpt *is* what shows, but it is rendered **from** the body:

```vue
<ContentRenderer :value="blogArticle" :excerpt="true">
```

My first projection dropped `body` and listed the nine fields the templates name. The guard was green. The excerpt on all seven cards had silently vanished, and I only caught it because I diffed the rendered page against the baseline and found two headings missing.

The actual fix is that @nuxt/content stores `excerpt` as **its own column**. Selecting `excerpt` instead of `body` keeps the card drawing exactly what it drew and leaves the full AST behind — which is where nearly all of the 90 % comes from.

A second round of diffing caught a smaller one: without `id`, `ContentRenderer` stops emitting `data-content-id`. Adding it restored byte-identical output.

## The guard, hardened by that miss

Three rules rather than "a projection exists":

1. Fields the overview **names** (`blogArticle.slug`, …) must all be projected — derived from the consumers' own source, so it tracks them.
2. Fields a component receives **without naming** must be projected too. `ContentRenderer` takes the whole row, so `excerpt` appears nowhere in ArticleCard's source; this rule states the dependency explicitly and fails with `ArticleCard.vue needs excerpt` — verified by removing the column and watching it fire.
3. `body` must not be in the projection.

The file records why rule 2 exists, because rule 1 alone read as sufficient and was not.

One more thing rule 1 catches that a template reading would not: `releaseDate` is on no card. The release gate in `useBlogContent` reads it, and a projection written from the templates would have published unreleased articles.

### And a bug in the check itself

The field scan first allowed whitespace around the dot, so it matched through a comment — `"…rendering an empty article.\n  if (slug.value…"` yielded a required field named `if`. Property accesses have no spaces in them; sentences ending in one of these words do. Pinned by a self-test.

## Gates

Suite: 85 tests, 26 files. Build green. Ratchet down to 352.

Refs: `PERF-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s