### PR TITLE
perf(blog): size article card images to the grid and defer them

### DIFF
--- a/components/features/blog/page/card/ArticleCard.vue
+++ b/components/features/blog/page/card/ArticleCard.vue
@@ -22,24 +22,33 @@ const title = computed(() => {
     v-if="blogArticle"
     class="bg-white dark:bg-gray-900/60 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm hover:shadow-md transition-shadow overflow-hidden">
     <NuxtLink
-      :to="`/${locale}/blog/${blogArticle.slug}`"
       v-posthog-capture="'blog-article-card-click'"
+      :to="`/${locale}/blog/${blogArticle.slug}`"
       class="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 rounded-xl">
       <div class="relative">
+        <!--
+          `sizes` in viewport fractions, matching the grid in
+          pages/blog/index.vue: one column, then two, then three. A fixed pixel
+          width cannot track a fluid column, and the previous `xl:1920px` had
+          @nuxt/image offer a 3840px source for a card about 373px wide.
+
+          Lazy because the overview's LCP is Top1's header above these cards.
+        -->
         <NuxtPicture
           v-if="blogArticle?.headerImage"
           :src="blogArticle?.headerImage"
           :alt="blogArticle?.headerImageAlt"
-          sizes="xs:300px sm:500px md:700px lg:1200px xl:1920px"
+          sizes="xs:100vw sm:50vw md:33vw"
           width="1920"
           height="1080"
           fit="cover"
           quality="80"
           format="avif,webp"
+          loading="lazy"
           :img-attrs="{ class: 'w-full h-48 object-cover rounded-t-xl' }"
         />
         <!-- Material 3 state layer -->
-        <div aria-hidden="true" class="absolute inset-0 bg-black/0 group-hover:bg-black/5 group-active:bg-black/10 transition-colors"></div>
+        <div aria-hidden="true" class="absolute inset-0 bg-black/0 group-hover:bg-black/5 group-active:bg-black/10 transition-colors"/>
       </div>
       <div class="p-4">
         <!-- title-large approximation -->
@@ -56,8 +65,7 @@ const title = computed(() => {
           />
         </div>
         <!-- body-medium content excerpt -->
-        <ContentRenderer class="text-gray-700 dark:text-gray-300 mt-3" :value="blogArticle" :excerpt="true">
-        </ContentRenderer>
+        <ContentRenderer class="text-gray-700 dark:text-gray-300 mt-3" :value="blogArticle" :excerpt="true"/>
       </div>
     </NuxtLink>
   </article>

--- a/tests/design-system/article-card-image.spec.ts
+++ b/tests/design-system/article-card-image.spec.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * `sizes` is a promise to the browser about how wide the image will be drawn.
+ * Get it wrong upward and every candidate width is inflated: @nuxt/image
+ * multiplies each entry by the device pixel ratio, so a card claiming 1920px
+ * ends up offering a 3840px source for a slot a few hundred pixels wide.
+ *
+ * Measured before the change, on the real blog overview with the Cloudflare
+ * provider active:
+ *
+ *   widths offered   300 500 600 700 1000 1200 1400 1920 2400 3840
+ *   card width       ~373px at 1440px viewport
+ *   loading="lazy"   0 of 9 images
+ *
+ * The promise and the layout live in different files, which is how they drift.
+ * So this reads the grid out of the overview page and requires the card's
+ * `sizes` to describe it: one column, then two, then three — expressed as
+ * viewport fractions, which stay true at every width instead of only at the
+ * one someone measured.
+ */
+
+const CARD = 'components/features/blog/page/card/ArticleCard.vue'
+const OVERVIEW = 'pages/blog/index.vue'
+
+/** `grid-cols-1 sm:grid-cols-2 md:grid-cols-3` → { xs: 1, sm: 2, md: 3 } */
+const GRID_COLUMNS = /(?:(xs|sm|md|lg|xl):)?grid-cols-(\d+)/g
+/** `xs:100vw sm:50vw md:33vw` → [['xs', 100], ['sm', 50], ['md', 33]] */
+const SIZE_ENTRY = /(xs|sm|md|lg|xl|2xl):(\d+)(vw|px)/g
+
+function read(file: string): string {
+  return readFileSync(`${repoRoot}/${file}`, 'utf8')
+}
+
+function gridColumns(): Record<string, number> {
+  const columns: Record<string, number> = {}
+  for (const [, breakpoint,
+count] of read(OVERVIEW).matchAll(GRID_COLUMNS)) {
+    columns[breakpoint ?? 'xs'] = Number(count)
+  }
+  return columns
+}
+
+function cardSizes(): Array<{ breakpoint: string, value: number, unit: string }> {
+  const attribute = /sizes="([^"]+)"/.exec(read(CARD))
+  if (!attribute) return []
+  return [...attribute[1]!.matchAll(SIZE_ENTRY)]
+    .map(([, breakpoint,
+value,
+unit]) => ({ breakpoint: breakpoint!, value: Number(value), unit: unit! }))
+}
+
+describe('article card image', () => {
+  it('reads the grid and the sizes attribute', () => {
+    // Without this, an empty grid and empty sizes would agree on everything.
+    expect(gridColumns()).toEqual({ xs: 1, sm: 2, md: 3 })
+    expect(cardSizes().length).toBeGreaterThan(2)
+  })
+
+  it('promises a width the grid actually gives it', () => {
+    const columns = gridColumns()
+    const mismatched = cardSizes()
+      .filter((size) => columns[size.breakpoint] !== undefined)
+      .filter((size) => {
+        // A fixed pixel width cannot track a fluid column.
+        if (size.unit !== 'vw') return true
+        const expected = Math.round(100 / columns[size.breakpoint]!)
+        // Gutters and container padding make the column slightly narrower, so
+        // rounding down is fine; over-promising is what this is about.
+        return size.value > expected + 1 || size.value < expected - 8
+      })
+      .map((size) => `${size.breakpoint}:${size.value}${size.unit} for ${columns[size.breakpoint]} columns`)
+
+    expect(mismatched).toEqual([])
+  })
+
+  it('does not offer a source wider than any column can be', () => {
+    // The widest container in this layout is 1536px (2xl); a third of it is
+    // ~460px. Anything above 640 describes a card that cannot exist.
+    const oversized = cardSizes().filter((size) => size.unit === 'px' && size.value > 640)
+    expect(oversized).toEqual([])
+  })
+
+  it('leaves the hero to load first', () => {
+    // The overview's LCP is Top1's header image. The cards below it are the
+    // eight that can wait — none of them was deferred.
+    expect(read(CARD)).toMatch(/loading="lazy"/)
+  })
+})


### PR DESCRIPTION
Implements `PERF-03`, test-first.

## Measured on the real page

Dev server with the Cloudflare image provider active, `/de/blog`, looking only at the seven card `<picture>` elements:

| | before | after |
|---|---|---|
| candidate widths | `300 500 600 700 1000 1200 1400 1920 2400 3840` | `253 320 506 640` |
| widest source | **3840 px** | **640 px** |
| `loading="lazy"` on the page | 0 of 9 | 7 of 9 |

The card is about 373 px wide at a 1440 px viewport. It was being offered a 3840 px source — `sizes` claimed `xl:1920px`, and @nuxt/image doubles each entry for high-DPR screens.

The two images that stay eager are Top1's header (the LCP) and the logo, which is what you want.

## The change

`sizes="xs:100vw sm:50vw md:33vw"` — the grid in `pages/blog/index.vue` is `grid-cols-1 sm:grid-cols-2 md:grid-cols-3`, so those fractions *are* the layout. A fixed pixel width cannot track a fluid column; that is why the old values were wrong at every viewport rather than just the widest one. The generated widths now land at 253/320/506/640, which follow the actual column.

## The guard

Not a hardcoded expected string. It reads the column counts out of the overview page and requires the card's `sizes` to describe them, so the two files can no longer drift apart silently — which is how they got here, sitting in different directories.

Three rules: entries must be viewport fractions matching the column count, no fixed pixel entry may exceed 640 (a third of the widest 1536 px container is ~460), and the card must be deferred. All three were red.

## Scope, stated

`Top1.vue` carries the **identical** `sizes` string and still does. It is a full-width hero, so `1920px` overshoots by far less — the container maxes out at 1536 — and it is the LCP element, where deferring would be actively wrong. It is the reason a 3840 px source still appears on the page. Worth its own look; not this finding.

## One thing in the diff that is not mine

Running the repo's own `eslint --fix` on the file also corrected three pre-existing violations: an attribute-order swap on `NuxtLink`, and two elements collapsed to self-closing. I checked they are rendering-neutral by diffing the served HTML before and after — the only difference was the dev server's port number in the og:image URLs.

They account for the warning count dropping 48 → 45.

## Gates

Suite: 85 tests, 26 files. Build green. Ratchet down to 352 / 45 / 30. Note #244 also lowers the error count to 352 by another route; if both land, the later one leaves the warning baseline slightly loose rather than wrong.

Refs: `PERF-03`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s