### PR TITLE
fix(a11y): declare the language of each endonym in the switcher

### DIFF
--- a/components/features/navigation/LanguageSelector.vue
+++ b/components/features/navigation/LanguageSelector.vue
@@ -17,8 +17,23 @@ const initialFocus = ref<'first' | 'last'>('first');
 const buttonId = computed(() => `lang-button-${props.variant}`);
 const dropdownId = computed(() => `lang-menu-${props.variant}`);
 
-const availableLocales = computed(() => locales.value.filter((i: any) => i.code !== locale.value));
-const currentLocale = computed(() => locales.value.find((i: any) => i.code === locale.value));
+/**
+ * What this component needs from a locale entry.
+ *
+ * `locales` is typed `(string | LocaleObject)[]` because the shorthand form is
+ * legal in nuxt.config, though this project never uses it. Describing the
+ * shape here rather than importing `LocaleObject` is deliberate: the name is
+ * exported by more than one package and the one from `@nuxtjs/i18n` is not the
+ * member of that union, so a type predicate written against it does not narrow
+ * anything (`TS2677`) and every `loc.code` stays an error.
+ */
+type SwitchableLocale = { code: string, name: string }
+
+const localeObjects = computed<SwitchableLocale[]>(() => (locales.value as Array<string | { code: string, name?: string }>)
+    .filter((entry): entry is { code: string, name?: string } => typeof entry !== 'string')
+    .map(entry => ({ code: entry.code, name: entry.name ?? entry.code })));
+const availableLocales = computed(() => localeObjects.value.filter(l => l.code !== locale.value));
+const currentLocale = computed(() => localeObjects.value.find(l => l.code === locale.value));
 
 const focusMenuItem = (position: 'first' | 'last' | number = 'first') => {
   const container = menuRef.value;
@@ -134,16 +149,16 @@ const onSelect = (localeCode: string) => {
 <template>
   <div v-if="variant === 'desktop'" class="relative">
     <button
-      @click="toggleDropdown"
-      :aria-label="t('navigation.change_language')"
       :id="buttonId"
+      :aria-label="t('navigation.change_language')"
       type="button"
+      ref="buttonRef"
       aria-haspopup="menu"
       :aria-expanded="isOpen ? 'true' : 'false'"
       :aria-controls="dropdownId"
-      ref="buttonRef"
-      @keydown="onButtonKeydown"
       class="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-surface)]/70 dark:hover:bg-[var(--color-surface)]/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)]"
+      @click="toggleDropdown"
+      @keydown="onButtonKeydown"
     >
       <FontAwesomeIcon :icon="faLanguage" class="text-lg" />
       <span class="uppercase">{{ currentLocale?.code }}</span>
@@ -161,23 +176,24 @@ const onSelect = (localeCode: string) => {
       <div
         v-if="isOpen"
         :id="dropdownId"
+        ref="menuRef"
         role="menu"
         :aria-labelledby="buttonId"
         tabindex="-1"
-        ref="menuRef"
-        @keydown="onMenuKeydown"
         class="absolute right-0 mt-2 w-48 overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-lg ring-1 ring-black/5 dark:border-[var(--color-border)] dark:bg-[var(--color-surface)]"
+        @keydown="onMenuKeydown"
       >
         <SwitchLocalePathLink
           v-for="loc in availableLocales"
           :key="loc.code"
           :locale="loc.code"
+          :hreflang="loc.code"
           role="menuitem"
           class="flex items-center gap-3 px-4 py-2 text-sm font-medium text-[var(--color-text)]/70 transition-colors hover:bg-brand-secondary/10 dark:text-[var(--color-text)]/85 dark:hover:bg-brand-secondary/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-secondary"
           @click="onSelect(loc.code)"
         >
           <span class="uppercase font-semibold text-brand-secondary">{{ loc.code }}</span>
-          <span>{{ loc.name }}</span>
+          <span :lang="loc.code">{{ loc.name }}</span>
         </SwitchLocalePathLink>
       </div>
     </Transition>
@@ -192,11 +208,12 @@ const onSelect = (localeCode: string) => {
       v-for="loc in availableLocales"
       :key="loc.code"
       :locale="loc.code"
+      :hreflang="loc.code"
       class="ml-4 flex items-center gap-3 rounded-xl px-6 py-2 text-sm font-medium text-[var(--color-text)]/70 transition-colors hover:bg-brand-secondary/10 dark:text-[var(--color-text)]/85 dark:hover:bg-brand-secondary/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-secondary"
       @click="onSelect(loc.code)"
     >
       <span class="uppercase font-semibold text-brand-secondary">{{ loc.code }}</span>
-      <span>{{ loc.name }}</span>
+      <span :lang="loc.code">{{ loc.name }}</span>
     </SwitchLocalePathLink>
   </div>
 </template>

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 352,
-  "eslintWarnings": 48,
-  "typeErrors": 30
+  "eslintErrors": 351,
+  "eslintWarnings": 39,
+  "typeErrors": 21
 }

--- a/tests/a11y/language-of-parts.spec.ts
+++ b/tests/a11y/language-of-parts.spec.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * The language switcher lists endonyms — "Deutsch", "English" — each written
+ * in the language it names. On a German page, "English" is a passage of
+ * English inside a `lang="de"` document, and vice versa.
+ *
+ * A screen reader picks its pronunciation rules from the nearest `lang`. With
+ * none on these spans it applies the document's, so a German synthesiser reads
+ * "English" as *Eng-lisch* and an English one reads "Deutsch" as *Doytsh*.
+ * The one control on the page whose whole job is to be recognised by a speaker
+ * of the other language is the one that gets mispronounced. That is WCAG 3.1.2,
+ * Language of Parts.
+ *
+ * `hreflang` on the link is the same fact stated for the destination: it tells
+ * assistive technology, and anything else reading the markup, what language
+ * lies on the other side before following it.
+ *
+ * The locale `code` is used rather than `iso`. @nuxtjs/i18n v10 dropped `iso`
+ * in favour of `language`, so the `iso: 'de-DE'` still written in nuxt.config
+ * is not something to depend on here; `de` and `en` are valid BCP 47 tags on
+ * their own.
+ */
+
+const SELECTOR = 'components/features/navigation/LanguageSelector.vue'
+
+/** An element whose entire content is the locale endonym. */
+const ENDONYM_ELEMENT = /<(\w+)([^>]*)>\{\{\s*loc\.name\s*\}\}<\/\1>/g
+/** The locale-switching link, opening tag only. */
+const LOCALE_LINK = /<SwitchLocalePathLink\b([^>]*)>/g
+
+/**
+ * The `<template>` block only.
+ *
+ * The script above it contains the line `// Navigation is handled by
+ * <SwitchLocalePathLink>, which resolves the …` — prose that reads as markup
+ * and was counted as a third, unmarked link on the first run. A comment
+ * mentioning a component is not a use of it.
+ */
+function selector(): string {
+  const source = readFileSync(`${repoRoot}/${SELECTOR}`, 'utf8')
+  const template = /<template>([\s\S]*)<\/template>/.exec(source)
+  if (!template) throw new Error(`no <template> block in ${SELECTOR}`)
+  return template[1]!
+}
+
+describe('language of parts', () => {
+  it('finds the elements it is meant to check', () => {
+    // Without this, a renamed component would pass every rule below.
+    const source = selector()
+    expect([...source.matchAll(ENDONYM_ELEMENT)]).toHaveLength(2)
+    expect([...source.matchAll(LOCALE_LINK)]).toHaveLength(2)
+
+    // The regex must not match an element that merely contains other text.
+    const other = '<span>{{ loc.code }}</span>'
+    ENDONYM_ELEMENT.lastIndex = 0
+    expect([...other.matchAll(ENDONYM_ELEMENT)]).toHaveLength(0)
+
+    // And the script block is out of scope — see selector().
+    expect(source).not.toContain('// Navigation is handled by')
+  })
+
+  it('marks each endonym with the language it is written in', () => {
+    const unmarked = [...selector().matchAll(ENDONYM_ELEMENT)]
+      .filter(([, , attributes]) => !/\blang="[^"]*loc\.code/.test(attributes!))
+      .map(([match]) => match)
+    expect(unmarked).toEqual([])
+  })
+
+  it('declares the language each locale link leads to', () => {
+    const unmarked = [...selector().matchAll(LOCALE_LINK)]
+      .filter(([, attributes]) => !/\bhreflang="[^"]*loc\.code/.test(attributes!))
+      .map(([match]) => match.slice(0, 60))
+    expect(unmarked).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `A11Y-09`, test-first.

## What a screen reader was doing

The switcher lists endonyms — "Deutsch", "English" — each written in the language it names. On a German page, "English" is a passage of English inside a `lang="de"` document.

A screen reader takes its pronunciation rules from the nearest `lang`, so with none on these spans it applies the document's: a German synthesiser reads "English" as *Eng-lisch*, an English one reads "Deutsch" as *Doytsh*. The one control on the page whose entire job is to be recognised by a speaker of the other language is the one that gets mispronounced. WCAG 3.1.2, Language of Parts.

`:lang="loc.code"` on the endonym, `:hreflang="loc.code"` on the link — four bindings, two switcher variants.

## Verified in the DOM

The dropdown is behind `v-if="isOpen"`, so it never appears in server-rendered HTML and `curl` sees nothing. I forced it open temporarily and read both locales:

```
/de   <span lang="en">English</span>    <a href="/en" … hreflang="en" role="menuitem">
/en   <span lang="de">Deutsch</span>    <a href="/de" … hreflang="de" role="menuitem">
```

That settles the one real uncertainty: `SwitchLocalePathLink` does forward `hreflang` through to the anchor rather than swallowing it.

`code` is used, not `iso`. @nuxtjs/i18n v10 replaced `iso` with `language`, so the `iso: 'de-DE'` still sitting in nuxt.config is not something to build on; `de` and `en` are valid BCP 47 tags on their own.

## Why the diff is bigger than four attributes

Adding them raised the type-error count by 4. Not a new defect — `locales` is typed `(string | LocaleObject)[]`, so **every** `loc.code` in the file was already an error, and I had just written four more. Two `(i: any)` casts were hiding the rest.

Raising the baseline for that would have been the wrong trade, so the union is narrowed once at the top instead.

That took two attempts, and the failed one is worth recording: importing `LocaleObject` from `@nuxtjs/i18n` and writing a type predicate against it made things **worse** (30 → 37), because that exported name is not the member of the union — `TS2677: A type predicate's type must be assignable to its parameter's type`, and the narrowing silently did nothing. Describing the needed shape locally works and does not depend on guessing which package owns the name.

Net: type errors **30 → 21**, warnings 48 → 39, and the two `any` casts are gone.

## Gates

Suite: 95 tests, 30 files. Build green. Ratchet down in all three columns.

Refs: `A11Y-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s