### PR TITLE
refactor(content): declare the locale list once

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 351,
+  "eslintErrors": 347,
   "eslintWarnings": 39,
   "typeErrors": 21
 }

--- a/server/api/__sitemap__/team.ts
+++ b/server/api/__sitemap__/team.ts
@@ -1,5 +1,6 @@
 import { queryCollection } from '@nuxt/content/server'
 import type { TeamDocument, TeamMember } from '~/types/team'
+import { locales } from '~/utils/content/locales'
 
 /**
  * Sitemap source for individual team profile pages.
@@ -10,13 +11,10 @@ import type { TeamDocument, TeamMember } from '~/types/team'
  * here, one entry per locale × member, so both /de/team/<slug> and
  * /en/team/<slug> end up in the per-locale sitemaps.
  */
-type LocaleKey = 'de' | 'en'
-
-const LOCALES: ReadonlyArray<LocaleKey> = ['de', 'en']
 
 export default defineEventHandler(async (event) => {
   const out: { loc: string }[] = []
-  for (const locale of LOCALES) {
+  for (const locale of locales) {
     const key = `team_${locale}` as 'team_de' | 'team_en'
     const docs = (await queryCollection(event, key).all()) as TeamDocument[]
     const doc = docs[0]

--- a/tests/architecture/locale-list.spec.ts
+++ b/tests/architecture/locale-list.spec.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo, repoRoot } from '../helpers/sources'
+import { locales } from '../../utils/content/locales'
+
+/**
+ * Which languages this site has is one fact, and it decides several things
+ * that must agree: the content collections that exist, the URLs the sitemap
+ * emits, the `Locale` type. A second copy of the list does not fail when it
+ * drifts — it succeeds at producing a smaller sitemap.
+ *
+ * `server/api/__sitemap__/team.ts` carried its own `['de', 'en']` plus its own
+ * `type LocaleKey = 'de' | 'en'`. Adding a third language would have left the
+ * team profiles out of that locale's sitemap silently: no error, no missing
+ * import, just fewer URLs than pages.
+ *
+ * The declaration is checked by value rather than by counting the literal
+ * `'de', 'en'`, so it keeps working when the list changes.
+ */
+
+const SOURCE_DIRS = ['components',
+  'pages',
+  'layouts',
+  'composables',
+  'utils',
+  'plugins',
+  'server',
+  'types']
+
+const CANONICAL = 'utils/content/locales.ts'
+
+/** An array or union that spells out every locale code. */
+function redeclarations(): string[] {
+  const asArray = new RegExp(locales.map((code) => `['"]${code}['"]`).join('\\s*,\\s*'))
+  const asUnion = new RegExp(locales.map((code) => `['"]${code}['"]`).join('\\s*\\|\\s*'))
+
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.ts', '.vue'])) {
+    const relative = relativeToRepo(file)
+    if (relative === CANONICAL) continue
+    const text = readFileSync(file, 'utf8')
+    text.split('\n').forEach((line, index) => {
+      if (asArray.test(line) || asUnion.test(line)) found.push(`${relative}:${index + 1}`)
+    })
+  }
+  return found
+}
+
+describe('locale list', () => {
+  it('has one declaration to point at', () => {
+    // Without this, a renamed module would make the rule vacuous.
+    expect([...locales]).toEqual(['de', 'en'])
+    const canonical = readFileSync(`${repoRoot}/${CANONICAL}`, 'utf8')
+    expect(canonical).toContain('as const')
+
+    // The patterns must actually recognise both spellings.
+    const asArray = new RegExp(locales.map((code) => `['"]${code}['"]`).join('\\s*,\\s*'))
+    const asUnion = new RegExp(locales.map((code) => `['"]${code}['"]`).join('\\s*\\|\\s*'))
+    expect(asArray.test("const LOCALES = ['de', 'en']")).toBe(true)
+    expect(asUnion.test("type LocaleKey = 'de' | 'en'")).toBe(true)
+    expect(asArray.test("const key = `team_${locale}`")).toBe(false)
+  })
+
+  it('is not spelled out a second time', () => {
+    expect(redeclarations()).toEqual([])
+  })
+})

--- a/utils/content/collections.ts
+++ b/utils/content/collections.ts
@@ -1,20 +1,24 @@
 import { defineCollection } from '@nuxt/content'
 import { z } from 'zod'
 
-export const locales = ['de', 'en'] as const
-export type Locale = (typeof locales)[number]
+import { locales } from './locales'
+import type { Locale } from './locales'
 
-export const withI18nMeta = <T extends z.ZodRawShape>(schema: z.ZodObject<T>) =>
-  schema.extend({
+// Both imported and re-exported: the factories below use them, and existing
+// `from './collections'` imports must keep resolving. A bare
+// `export … from './locales'` would forward the names without binding them
+// here, which is a ReferenceError at runtime and TS2304 at compile time.
+export { locales }
+export type { Locale }
+
+export const withI18nMeta = <T extends z.ZodRawShape>(schema: z.ZodObject<T>) => schema.extend({
     translationKey: z.string().optional(),
     canonical: z.string().url().optional(),
     alternates: z
-      .array(
-        z.object({
+      .array(z.object({
           hreflang: z.string(),
           href: z.string().url()
-        })
-      )
+        }))
       .optional()
   })
 
@@ -23,8 +27,7 @@ type CollectionFactory = (locale: Locale) => ReturnType<typeof defineCollection>
 export const createLocalizedCollections = (
   name: string,
   factory: CollectionFactory
-): Record<string, ReturnType<typeof defineCollection>> =>
-  locales.reduce<Record<string, ReturnType<typeof defineCollection>>>((acc, locale) => {
+): Record<string, ReturnType<typeof defineCollection>> => locales.reduce<Record<string, ReturnType<typeof defineCollection>>>((acc, locale) => {
     acc[`${name}_${locale}`] = factory(locale)
     return acc
   }, {})
@@ -32,5 +35,4 @@ export const createLocalizedCollections = (
 export const defineLocalizedCollections = (
   name: string,
   configFactory: (locale: Locale) => Parameters<typeof defineCollection>[0]
-) =>
-  createLocalizedCollections(name, (locale) => defineCollection(configFactory(locale)))
+) => createLocalizedCollections(name, (locale) => defineCollection(configFactory(locale)))

--- a/utils/content/locales.ts
+++ b/utils/content/locales.ts
@@ -1,0 +1,14 @@
+/**
+ * The languages this site publishes, and the only place they are named.
+ *
+ * Split out of `collections.ts` so it can be imported from anywhere without
+ * dragging along `@nuxt/content`'s `defineCollection` and `zod` — a Nitro
+ * route handler needs the list, not the collection factory, and pulling a
+ * build-time API into the server runtime to get at a two-element array is a
+ * bad trade.
+ *
+ * `collections.ts` re-exports both, so existing imports keep working.
+ */
+export const locales = ['de', 'en'] as const
+
+export type Locale = (typeof locales)[number]


### PR DESCRIPTION
Implements the first part of `OPS-09`, test-first. Scope is stated at the bottom.

## What drifts, and how quietly

`server/api/__sitemap__/team.ts` carried its own copy:

```ts
type LocaleKey = 'de' | 'en'
const LOCALES: ReadonlyArray<LocaleKey> = ['de', 'en']
```

while `utils/content/collections.ts` already exported the same list as the source for every content collection.

The failure mode is what makes this worth fixing rather than noting. Adding a third language would leave that locale's team profiles out of the sitemap — no error, no missing import, no failing build. Just a sitemap with fewer URLs than the site has pages, which is the kind of thing you find out from Search Console months later.

## The change

`utils/content/locales.ts` now holds the list, and `collections.ts` re-exports it so existing imports keep working. Splitting it out rather than importing `collections.ts` from the handler is the point: that module pulls in `defineCollection` and `zod`, and dragging a build-time API into the Nitro runtime to reach a two-element array is a bad trade.

## Two mistakes worth recording

I wrote `export { locales } from './locales'` and the content config died with `ReferenceError: locales is not defined` — a bare re-export forwards a name without binding it in the module, and `collections.ts` uses the list in its own factories. The test suite caught it immediately.

Then the identical mistake for the type: `export type { Locale } from './locales'` gave `TS2304: Cannot find name 'Locale'` twice. Both now import *and* export, with a comment saying why.

## Verified

`/api/__sitemap__/team` before and after: **26 entries, 13 per locale**, unchanged. `/de/blog` still renders its 8 articles.

## The guard

The rule is "the locale codes are spelled out in exactly one file", and it checks by **value** — it builds its patterns from the imported list, so it keeps working when the list changes rather than hardcoding `'de', 'en'`. Both spellings are covered, the array and the union, since the handler had one of each.

Excluded by design: `\`team_${locale}\` as 'team_de' | 'team_en'` in that same handler. The collection keys are a @nuxt/content naming detail, not a second declaration of which languages exist, and the pattern does not match them.

## Scope

`OPS-09` also raises missing error handling and missing caching on that handler. Both involve choices — what to do when a locale's collection is unavailable, and what TTL is right — so they are not decision-free and are not in here.

## Gates

Suite: 100 tests, 32 files. Build green. Ratchet down to 347 errors.

Refs: `OPS-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s