### PR TITLE
fix(a11y): one carousel live region, silent while it rotates itself

### DIFF
--- a/components/features/home/carousel/Carousel.vue
+++ b/components/features/home/carousel/Carousel.vue
@@ -100,8 +100,15 @@ useHead(() => {
   }
 })
 
-const goTo = (index: number) => {
+// Whether the slide showing now is the one the user asked for. The live
+// region reads it: the WAI-ARIA APG wants a carousel to announce changes the
+// user triggered, and to stay quiet while it rotates on its own — twelve
+// unprompted announcements a minute is what `aria-live` exists to avoid.
+const userInitiated = ref(false)
+
+const goTo = (index: number, byUser = true) => {
   if (slidesCount.value === 0) return
+  userInitiated.value = byUser
   if (props.loop) {
     current.value = (index + slidesCount.value) % slidesCount.value
   } else {
@@ -109,11 +116,11 @@ const goTo = (index: number) => {
   }
 }
 
-const next = () => {
-  goTo(current.value + 1)
+const next = (byUser = true) => {
+  goTo(current.value + 1, byUser)
 }
-const prev = () => {
-  goTo(current.value - 1)
+const prev = (byUser = true) => {
+  goTo(current.value - 1, byUser)
 }
 
 const start = () => {
@@ -126,7 +133,7 @@ const start = () => {
   // Respect prefers-reduced-motion
   if (prefersReducedMotion.value) return
   timer.value = setInterval(() => {
-    if (!isHovering.value) next()
+    if (!isHovering.value) next(false)
   }, props.interval)
 }
 
@@ -199,6 +206,7 @@ const trackStyle = computed(() => ({
 
 // Accessibility: Live text for current slide
 const liveText = computed(() => {
+  if (!userInitiated.value) return ''
   const slide = normalizedSlides.value[current.value]
   if (!slide) return ''
   return getSlideAriaText(slide, current.value, slidesCount.value, t)
@@ -253,7 +261,6 @@ const componentFor = (slide: NormalizedSlide) => {
       <div
         class="absolute inset-0 z-30 flex h-full transition-transform duration-500 ease-out"
         :style="trackStyle"
-        aria-live="polite"
       >
         <div
           v-for="(s, i) in normalizedSlides"

--- a/tests/a11y/carousel-live-region.spec.ts
+++ b/tests/a11y/carousel-live-region.spec.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * The carousel had two live regions competing for the same event.
+ *
+ * The slide track carried `aria-live="polite"` and contains every slide —
+ * headings, excerpts, dates, buttons. A sibling `<span class="sr-only"
+ * aria-live="polite">` carried a purpose-built announcement. Both react to the
+ * same slide change, and the track is not a summary of anything: what changes
+ * inside it is `aria-hidden`, `inert` and a transform across a subtree holding
+ * the full text of five slides.
+ *
+ * The second half is the one a listener actually notices. Autoplay advances
+ * every 5000 ms, so the announcement fired unprompted, twelve times a minute,
+ * over whatever the user was doing. The WAI-ARIA APG is explicit that a
+ * carousel should announce slide changes the *user* asked for — rotation is
+ * ambient, and ambient changes are what `aria-live` is meant not to be used
+ * for.
+ *
+ * So: one region, and it stays silent while the carousel rotates on its own.
+ */
+
+const CAROUSEL = 'components/features/home/carousel/Carousel.vue'
+
+function carousel(): string {
+  return readFileSync(`${repoRoot}/${CAROUSEL}`, 'utf8')
+}
+
+describe('carousel live region', () => {
+  it('has exactly one', () => {
+    const regions = carousel().match(/aria-live=/g) ?? []
+    expect(regions).toHaveLength(1)
+  })
+
+  it('is the dedicated sr-only one, not the slide track', () => {
+    const source = carousel()
+    expect(source).toMatch(/<span class="sr-only" aria-live="polite">/)
+
+    // The track is the element carrying the sliding transform; it must not
+    // also be announcing.
+    const track = /<div\b[^>]*:style="trackStyle"[^>]*>/.exec(source)?.[0]
+    expect(track).toBeDefined()
+    expect(track).not.toContain('aria-live')
+  })
+
+  it('stays silent while autoplay is driving', () => {
+    const source = carousel()
+
+    // The interval must advance without claiming the user asked for it, and
+    // the announcement must be conditioned on that distinction.
+    expect(source).toMatch(/setInterval\([\s\S]{0,120}next\(false\)/)
+    expect(source).toMatch(/const liveText = computed\(\(\) => \{[\s\S]*?userInitiated/)
+  })
+})


### PR DESCRIPTION
Implements `A11Y-07`, test-first.

## Two regions, one event

The slide track carried `aria-live="polite"` and contains every slide — headings, excerpts, dates, buttons. A sibling `<span class="sr-only" aria-live="polite">` carried a purpose-built announcement. Both reacted to the same slide change.

The track is not a summary of anything. What changes inside it is `aria-hidden`, `inert` and a transform, across a subtree holding the full text of five slides. The `aria-live` comes off it; the dedicated region is the right one and is enough.

## The half a listener actually notices

Autoplay advances every 5000 ms, so the announcement fired **unprompted, twelve times a minute**, over whatever the user was doing. The WAI-ARIA APG is explicit that a carousel should announce the changes a user asked for — ambient rotation is what `aria-live` exists not to be used for.

`goTo` now records whether the change came from a person. Every user path defaults to `true` (buttons, dots, arrow keys, swipe); only the interval calls `next(false)`. `liveText` returns empty otherwise.

## Verified rendered

Initial render, `/de`:

```
<span class="sr-only" aria-live="polite"></span>     ← empty, nothing was announced
```

And the negative control, flipping the initial flag to `true`:

```
<span class="sr-only" aria-live="polite">Bild 1 von 5: Spawn-Bereich auf unserem Server (Screenshot)</span>
```

so the silence is the gate doing its job, not the text having gone missing. Restored, and the region is empty again.

Worth noting the previous behaviour that this also fixes: the region was populated on **first paint**, so the page could announce "Bild 1 von 5 …" on load, before any interaction.

## One count that looks wrong and is not

The page carries three `aria-live` regions, not one. Two belong to `ServerAddressCard` — the copy-to-clipboard confirmations, one per address — and are unrelated and correct. The carousel contributes exactly one.

## The guard

Three rules: the component declares one `aria-live`; the element carrying `trackStyle` is not it; and the interval advances via `next(false)` while `liveText` is conditioned on that distinction. All three were red.

The middle rule is written against the track's `:style="trackStyle"` binding rather than its position in the file, so it keeps pointing at the right element if the template moves.

## Gates

Suite: 105 tests, 34 files. Build green. Ratchet unchanged at 347 / 39 / 21.

Refs: `A11Y-07`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s