### PR TITLE
fix(a11y): hand focus back to the toggle when the mobile menu closes

### DIFF
--- a/components/features/navigation/NavigationBar.vue
+++ b/components/features/navigation/NavigationBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, useRoute, onKeyStroke } from '#imports';
+import { ref, computed, watch, nextTick, useRoute, onKeyStroke } from '#imports';
 import NavigationItem from './NavigationItem.vue'
 import LanguageSelector from './LanguageSelector.vue'
 import NavigationIconButton from '~/components/base/buttons/NavigationIconButton.vue'
@@ -22,6 +22,10 @@ withDefaults(defineProps<{
 const mobileMenuOpen = ref(false);
 const openGroup = ref<string | null>(null);
 const mobileMenuId = 'mobile-menu-panel';
+// Closing the panel unmounts it. Without these, focus sitting inside it has
+// nowhere to go and lands on <body>.
+const mobileToggleRef = ref<{ $el?: HTMLElement } | null>(null);
+const mobileMenuRef = ref<HTMLElement | null>(null);
 // Verwende die reaktive i18n-Locale; localePath nutzt automatisch die aktuelle Sprache
 const localePath = useLocalePath();
 // NUXT_PUBLIC_DISCORD_URL still overrides this — Nuxt folds it into the same
@@ -90,8 +94,17 @@ const toggleGroup = (key: string) => {
 }
 
 const closeMenus = () => {
+  // Only reclaim focus if it was in the panel about to disappear. A route
+  // change closes the menu too, and there the user is already somewhere else.
+  const hadFocus = import.meta.client
+    && !!mobileMenuRef.value?.contains(document.activeElement)
+
   openGroup.value = null
   mobileMenuOpen.value = false
+
+  if (hadFocus) {
+    nextTick(() => mobileToggleRef.value?.$el?.focus())
+  }
 }
 
 watch(
@@ -161,6 +174,7 @@ onKeyStroke('Escape', () => closeMenus())
 
         <div class="lg:hidden">
           <NavigationIconButton
+            ref="mobileToggleRef"
             :icon="mobileMenuOpen ? ['fas','times'] : ['fas','bars']"
             :aria-label="t('navigation.toggle_mobile_menu')"
             :aria-controls="mobileMenuId"
@@ -189,6 +203,7 @@ onKeyStroke('Escape', () => closeMenus())
       >
         <nav
           :id="mobileMenuId"
+          ref="mobileMenuRef"
           class="absolute left-0 right-0 top-0 z-50 mx-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-lg dark:border-[var(--color-border)] dark:bg-[var(--color-surface)]"
           role="navigation"
           :aria-label="t('navigation.mobile')"

--- a/tests/a11y/mobile-menu-focus.spec.ts
+++ b/tests/a11y/mobile-menu-focus.spec.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * Pressing Escape with the mobile menu open removes the `<nav>` from the DOM
+ * while focus is inside it. The browser has nowhere to put focus, so it falls
+ * to `<body>` — a keyboard user loses their position entirely and starts
+ * tabbing from the top of the page.
+ *
+ * The fix is the smaller half of what the finding proposes, and deliberately
+ * so. This menu is a **disclosure**, not a modal dialog: the toggle carries
+ * `aria-expanded` and `aria-controls`, the panel is a labelled `role=
+ * "navigation"`. The WAI-ARIA APG does not ask for a focus trap in that
+ * pattern, and `inert`-ing the page behind it is a decision about whether the
+ * overlay is meant to be modal — not a defect. What is a defect is dropping
+ * focus on the floor.
+ *
+ * So: when the menu closes and focus was inside it, focus returns to the
+ * button that opened it. `LanguageSelector` already does exactly this, and the
+ * containment check is why a route change closing the menu does not yank focus
+ * away from wherever the user actually is.
+ *
+ * Not covered here: whether the browser really moves focus. That needs a real
+ * one, and this component wants a Nuxt runtime to mount. The check below holds
+ * the wiring in place; it does not claim to have watched it work.
+ */
+
+const NAVBAR = 'components/features/navigation/NavigationBar.vue'
+
+function navbar(): string {
+  return readFileSync(`${repoRoot}/${NAVBAR}`, 'utf8')
+}
+
+describe('mobile menu focus', () => {
+  it('keeps a handle on the toggle and the panel', () => {
+    const source = navbar()
+    // Without refs there is nothing to return focus to, and no way to know
+    // whether focus is inside the panel.
+    expect(source).toMatch(/ref="mobileToggleRef"/)
+    expect(source).toMatch(/ref="mobileMenuRef"/)
+    expect(source).toMatch(/const mobileToggleRef = ref/)
+    expect(source).toMatch(/const mobileMenuRef = ref/)
+  })
+
+  it('returns focus to the toggle when closing', () => {
+    const closeMenus = /const closeMenus = \(\) => \{[\s\S]*?\n\}/.exec(navbar())?.[0]
+    expect(closeMenus).toBeDefined()
+    expect(closeMenus).toContain('focus()')
+    expect(closeMenus).toContain('mobileToggleRef')
+  })
+
+  it('only does so when focus was inside the panel', () => {
+    const closeMenus = /const closeMenus = \(\) => \{[\s\S]*?\n\}/.exec(navbar())?.[0]
+    // A route change also closes the menu. Moving focus then would take it
+    // from wherever the user landed.
+    expect(closeMenus).toContain('contains(document.activeElement)')
+  })
+
+  it('is what Escape goes through', () => {
+    // The path that exposed the bug must not bypass the restoration.
+    expect(navbar()).toMatch(/onKeyStroke\('Escape',\s*\(\) => closeMenus\(\)\)/)
+  })
+})


### PR DESCRIPTION
Implements the defensible core of `A11Y-08`, test-first. What I left out, and why, is the larger part of this description.

## The defect

`onKeyStroke('Escape', () => closeMenus())` removes the `<nav>` from the DOM while focus is inside it. The browser has nowhere to put focus, so it falls to `<body>`: the keyboard user loses their position entirely and starts tabbing from the top of the page.

`closeMenus()` now returns focus to the button that opened the menu — the pattern `LanguageSelector` already uses in this codebase.

## Deliberately not done

The finding also asks for a focus trap and for `inert` on the page behind the overlay. Its own verification undercuts both, and I agree:

- **This is a disclosure, not a modal.** The toggle carries `aria-expanded` and `aria-controls`; the panel is a labelled `role="navigation"`. The WAI-ARIA APG does not ask for a focus trap in that pattern.
- **The 2.4.11 argument does not hold.** `bg-black/40` with `backdrop-blur-sm` darkens and blurs the page behind, it does not fully obscure it, and 2.4.11 (Minimum) only requires that the focused element is not entirely hidden.

Whether the overlay should be modal at all is a design decision, not a defect, so `inert` is not in here.

## One condition that matters

Focus is only reclaimed when it was **inside the panel**:

```ts
const hadFocus = import.meta.client && !!mobileMenuRef.value?.contains(document.activeElement)
```

A route change also calls `closeMenus()`. Without the check, navigating would yank focus to the hamburger button from wherever the user actually landed — trading one focus bug for another.

## What I verified, and what I did not

Confirmed in the rendered DOM that both refs point at real elements:

```html
<button type="button" aria-label="Mobile Menü umschalten" aria-controls="mobile-menu-panel" aria-expanded="false">
<nav id="mobile-menu-panel" role="navigation" aria-label="Mobile Navigation">
```

**I did not watch the focus move.** That needs a real browser, and this component wants a Nuxt runtime to mount, so the guard holds the wiring in place rather than the behaviour. The test file says so rather than implying more than it checks.

## The guard

Four rules: both refs exist and are bound in the template; `closeMenus` calls `focus()` on the toggle; it does so only when `contains(document.activeElement)`; and the Escape handler still routes through `closeMenus()` rather than setting the flag directly — the last one because several other call sites *do* set `mobileMenuOpen = false` inline, and the path that exposed this bug must not become one of them.

## Gates

Suite: 106 tests, 34 files. Build green. Ratchet unchanged at 347 / 39 / 21.

Refs: `A11Y-08`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s