### PR TITLE
fix(seo): point the sitemap Language column at the node that exists

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -123,7 +123,11 @@ export default defineNuxtConfig({
         xslColumns: [
             {label: 'URL', width: '50%'},
             {label: 'Last Modified', select: 'sitemap:lastmod', width: '25%'},
-            {label: 'Language', select: 'sitemap:hreflang', width: '25%'}
+            // Alternates are attributes on <xhtml:link>, not children in the
+            // sitemap namespace — 'sitemap:hreflang' matched nothing and the
+            // column rendered empty in every row. The xhtml namespace is
+            // already declared by the stylesheet.
+            {label: 'Language', select: 'xhtml:link/@hreflang', width: '25%'}
         ],
         // Team profiles live in a data-type content collection so they're
         // not auto-discovered. We materialise the per-member URLs through

--- a/tests/seo/sitemap-xsl-columns.spec.ts
+++ b/tests/seo/sitemap-xsl-columns.spec.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * `xslColumns` decides what the human-readable sitemap view shows. Each entry's
+ * `select` is dropped verbatim into `<xsl:value-of select="…"/>` inside a
+ * `for-each` over `sitemap:urlset/sitemap:url`, so an XPath that matches
+ * nothing produces an empty column rather than an error — the failure looks
+ * like missing data, which is the worst thing it could look like on a page
+ * whose whole job is to show you your sitemap.
+ *
+ * The `Language` column selected `sitemap:hreflang`. Measured on a rendered
+ * child sitemap:
+ *
+ *   <url> elements               29
+ *   <sitemap:hreflang> elements   0
+ *   <xhtml:link hreflang="…">    67
+ *
+ * There is no `hreflang` element in the sitemap namespace. Alternates are an
+ * *attribute* on `<xhtml:link>`, and that namespace is already declared in the
+ * stylesheet, so `xhtml:link/@hreflang` is what reaches them.
+ *
+ * The check is written against the element and attribute names a sitemap
+ * actually contains, so a column pointing at an invented node fails here
+ * rather than rendering blank in production.
+ */
+
+const CONFIG = 'nuxt.config.ts'
+
+/** Nodes a urlset entry can offer. `loc` and `lastmod` are sitemap children. */
+const SITEMAP_CHILDREN = ['loc',
+  'lastmod',
+  'changefreq',
+  'priority']
+/** Alternates live on xhtml:link, as attributes. */
+const XHTML_ATTRIBUTES = ['hreflang',
+  'href',
+  'rel']
+
+/**
+ * Every column, including the ones without a `select`.
+ *
+ * The URL column has none — the module renders it itself and filters it out
+ * before emitting `xsl:value-of` at all. Requiring `select:` in the pattern
+ * silently dropped it, which is how the first version of this file ended up
+ * parsing two columns out of three.
+ */
+function columns(): Array<{ label: string, select: string }> {
+  const source = readFileSync(`${repoRoot}/${CONFIG}`, 'utf8')
+  const block = /xslColumns:\s*\[([\s\S]*?)\n\s*\]/.exec(source)
+  if (!block) return []
+  return [...block[1]!.matchAll(/\{\s*label:\s*'([^']+)'([^}]*)\}/g)]
+    .map(([, label,
+rest]) => ({
+      label: label!,
+      select: /select:\s*'([^']*)'/.exec(rest!)?.[1] ?? ''
+    }))
+}
+
+/** Can this XPath name a node a sitemap entry actually has? */
+function resolvable(select: string): boolean {
+  if (!select) return true // the URL column is rendered by the module itself
+  const sitemapChild = /^sitemap:(\w+)$/.exec(select)
+  if (sitemapChild) return SITEMAP_CHILDREN.includes(sitemapChild[1]!)
+  const xhtmlAttribute = /^xhtml:link\/@(\w+)$/.exec(select)
+  if (xhtmlAttribute) return XHTML_ATTRIBUTES.includes(xhtmlAttribute[1]!)
+  return false
+}
+
+describe('sitemap xsl columns', () => {
+  it('reads the column definitions', () => {
+    // Without this, an unparsed config would pass the rule below.
+    const all = columns()
+    expect(all.length).toBeGreaterThan(2)
+    expect(all.map((c) => c.label)).toContain('Language')
+
+    // The resolver has to tell a real node from an invented one.
+    expect(resolvable('sitemap:lastmod')).toBe(true)
+    expect(resolvable('sitemap:hreflang')).toBe(false)
+    expect(resolvable('xhtml:link/@hreflang')).toBe(true)
+    expect(resolvable('xhtml:link/@nonsense')).toBe(false)
+  })
+
+  it('every column selects something a sitemap entry has', () => {
+    const unresolvable = columns()
+      .filter((c) => !resolvable(c.select))
+      .map((c) => `${c.label}: ${c.select}`)
+    expect(unresolvable).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `SEO-09`, test-first.

## An empty column, not an error

`xslColumns` puts each entry's `select` verbatim into `<xsl:value-of select="…"/>`, so an XPath that matches nothing renders **blank** rather than failing. On a page whose entire job is to show you your sitemap, missing data is the worst thing a bug could look like.

The `Language` column selected `sitemap:hreflang`. There is no such element — alternates are an *attribute* on `<xhtml:link>`. Counted on a rendered child sitemap:

| | |
|---|---|
| `<url>` entries | 29 |
| `<sitemap:hreflang>` elements | **0** |
| `<xhtml:link hreflang="…">` | 67 |

## Resolved against the real document

Rather than argue from the schema, I ran both XPaths against the served sitemap:

```
/de           sitemap:hreflang=None   xhtml:link/@hreflang='de-DE'
/de/blog      sitemap:hreflang=None   xhtml:link/@hreflang='de-DE'
/de/bluemap   sitemap:hreflang=None   xhtml:link/@hreflang='de-DE'
```

And confirmed the stylesheet already declares the namespace the new path needs:

```
xmlns:xhtml="http://www.w3.org/1999/xhtml"
```

After the change the served stylesheet emits `<xsl:value-of select="xhtml:link/@hreflang"/>`.

There is a mild irony here worth recording: @nuxtjs/sitemap generates the `xhtml:link` alternates perfectly well. The blank column was hiding correct output, not broken output.

## The guard

Not a spelling rule. It knows which children a `<url>` entry can have (`loc`, `lastmod`, `changefreq`, `priority`) and which attributes live on `xhtml:link`, and rejects a `select` naming anything else. So an invented node fails here instead of rendering blank in production.

The URL column, which has no `select` at all because the module renders it itself, is accepted rather than flagged — and that case is exactly what the self-test caught: my first parser required `select:` and quietly read **two** columns out of three. It now parses the shape without one, and asserts the count.

## Gates

Suite: 104 tests, 34 files. Build green. Ratchet unchanged at 347 / 39 / 21.

Refs: `SEO-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s