### PR TITLE
fix(seo): declare one sitemap in robots.txt, not a redirect alongside it

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,7 +100,9 @@ export default defineNuxtConfig({
         // Allow indexing for all crawlers by default. Per-route exclusions (legal pages, etc.)
         // are handled via routeRules. Blocking `/_nuxt/` would hide JS/CSS from crawlers and
         // break rendering for Googlebot, so we don't disallow anything globally here.
-        sitemap: ['/sitemap.xml']
+        // No `sitemap:` entry here. @nuxtjs/sitemap pushes the correct one
+        // itself (/sitemap_index.xml under the i18n prefix strategy); adding
+        // /sitemap.xml only announced a second URL that 307s to the first.
     },
     i18n: {
         strategy: 'prefix',

--- a/scripts/seo-check.mjs
+++ b/scripts/seo-check.mjs
@@ -302,6 +302,34 @@ const expandSitemapUrls = async (path) => {
  * what stands in its place, so a regression upstream is reported rather than
  * absorbed.
  */
+/**
+ * Every sitemap robots.txt announces must be the real thing.
+ *
+ * A directive pointing at a redirect is not a second sitemap, it is a hop —
+ * and the two sources that write these lines (nuxt.config's `robots.sitemap`
+ * and @nuxtjs/sitemap's own hook) cannot see each other, so a duplicate is
+ * easy to reintroduce and invisible without asking the server.
+ */
+const checkRobotsSitemaps = async () => {
+  const robots = await fetchRaw('/robots.txt')
+  const declared = robots.body
+    .split('\n')
+    .map((line) => /^Sitemap:\s*(\S+)/i.exec(line)?.[1])
+    .filter(Boolean)
+
+  if (declared.length === 0) {
+    err('/robots.txt', 'robots.txt declares no sitemap')
+    return
+  }
+
+  for (const target of declared) {
+    const res = await fetchRaw(new URL(target).pathname)
+    if (res.status !== 200) {
+      err('/robots.txt', `Declared sitemap ${target} answered ${res.status}, expected 200`)
+    }
+  }
+}
+
 const checkSitemapAcceptsQueryString = async () => {
   const index = await fetchRaw('/sitemap_index.xml')
   const child = load(index.body, { xmlMode: true })('sitemap > loc').first().text().trim()
@@ -354,6 +382,7 @@ const main = async () => {
     checkRobots(),
     checkSitemap(STATIC_ROUTES, NOINDEX_ROUTES),
     checkSitemapAcceptsQueryString(),
+    checkRobotsSitemaps(),
     ...targets.map((t) => checkPage(t))
   ])
 

--- a/tests/seo/robots-sitemap.spec.ts
+++ b/tests/seo/robots-sitemap.spec.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * `robots.txt` announced two sitemaps where there is one.
+ *
+ * `nuxt.config.ts` declared `robots: { sitemap: ['/sitemap.xml'] }`, and
+ * @nuxtjs/sitemap independently pushes its own entry — `/sitemap_index.xml`,
+ * because the i18n prefix strategy makes this a multi-sitemap setup.
+ * @nuxtjs/robots deduplicates identical strings, and those two are not
+ * identical, so both survived:
+ *
+ *   Sitemap: https://onelitefeather.net/sitemap.xml
+ *   Sitemap: https://onelitefeather.net/sitemap_index.xml
+ *
+ * The first is not a second sitemap. It is a **redirect** to the second —
+ * measured as `307 → /sitemap_index.xml`. (The finding said 301; the installed
+ * @nuxtjs/sitemap 8.3.2 issues a 307.) So a crawler is handed one real URL and
+ * one hop to the same place.
+ *
+ * The module supplies the correct directive on its own, which is why the fix
+ * is a deletion rather than a correction.
+ */
+
+const CONFIG = 'nuxt.config.ts'
+const GATE = 'scripts/seo-check.mjs'
+
+function read(file: string): string {
+  return readFileSync(`${repoRoot}/${file}`, 'utf8')
+}
+
+describe('robots sitemap directives', () => {
+  it('are left to the sitemap module', () => {
+    const robots = /robots:\s*\{([\s\S]*?)\n\s{4}\}/.exec(read(CONFIG))?.[1]
+    expect(robots).toBeDefined()
+    // Hand-declaring one only adds a line the module did not ask for.
+    expect(robots).not.toMatch(/sitemap:\s*\[/)
+  })
+
+  it('are checked for real by the SEO gate', () => {
+    const gate = read(GATE)
+    expect(gate).toMatch(/checkRobotsSitemaps/)
+
+    const check = /const checkRobotsSitemaps[\s\S]*?\n\}/.exec(gate)?.[0]
+    expect(check).toBeDefined()
+    // A declared sitemap must resolve directly — a redirect is the defect.
+    expect(check).toContain('Sitemap:')
+    expect(check).toMatch(/status !== 200/)
+  })
+})


### PR DESCRIPTION
Implements `SEO-07`, test-first.

## Two lines, one sitemap

`nuxt.config.ts` declared `robots: { sitemap: ['/sitemap.xml'] }`, and @nuxtjs/sitemap independently pushes its own — `/sitemap_index.xml`, because the i18n prefix strategy makes this a multi-sitemap setup. @nuxtjs/robots deduplicates identical strings, and those two are not identical:

```
Sitemap: https://onelitefeather.net/sitemap.xml
Sitemap: https://onelitefeather.net/sitemap_index.xml
```

The first is not a second sitemap. It is a hop to the second — measured as **307 → /sitemap_index.xml**.

*(The finding says 301. The installed @nuxtjs/sitemap is **8.3.2**, not the 7.6.0 its verification was written against, and it issues a 307. The behaviour is otherwise as described — worth re-measuring rather than trusting the note.)*

After the deletion, robots.txt carries exactly one directive and it answers 200 directly.

## A gate assertion, not just a config edit

The two sources that write these lines — `nuxt.config`'s `robots.sitemap` and the sitemap module's own hook — cannot see each other. A duplicate is easy to reintroduce and invisible without asking the server, so `checkRobotsSitemaps()` now parses every `Sitemap:` line out of the served robots.txt and requires each to answer 200. A redirect fails it.

Verified it runs, by flipping its expected status to 999 inside that function only:

```
/robots.txt
  ✗ Declared sitemap https://onelitefeather.net/sitemap_index.xml answered 200, expected 200
```

Restored, the full gate reports `0 error(s), 0 warning(s), 10 route(s) checked`.

## Gates

Suite: 115 tests, 38 files. Build green. Ratchet unchanged at 334 / 39 / 21.

Refs: `SEO-07`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s