### PR TITLE
fix(seo): give the legal pages their own title

### DIFF
--- a/pages/imprint.vue
+++ b/pages/imprint.vue
@@ -7,6 +7,10 @@ definePageMeta({
 });
 
 usePageSeo({
+  // Without this, usePageSeo falls back to the site name and overwrites
+  // <title>, og:title and twitter:title with it — the definePageMeta title
+  // above never reaches any of the three.
+  title: t('blog.imprint.title'),
   description: t('blog.imprint.description'),
   robots: 'noindex, follow',
 })

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -7,6 +7,10 @@ definePageMeta({
 });
 
 usePageSeo({
+  // Without this, usePageSeo falls back to the site name and overwrites
+  // <title>, og:title and twitter:title with it — the definePageMeta title
+  // above never reaches any of the three.
+  title: t('blog.privacy.title'),
   description: t('blog.privacy.description'),
   robots: 'noindex, follow',
 })

--- a/tests/seo/page-titles.spec.ts
+++ b/tests/seo/page-titles.spec.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * `usePageSeo` falls back to the site name when given no `title`, and that one
+ * value becomes `<title>`, `og:title` and `twitter:title` at once. Omitting it
+ * does not leave the title alone — it overwrites it with the site name.
+ *
+ * Measured on the dev server before the change:
+ *
+ *   /de/imprint   <title>OneLiteFeather Network | OneLiteFeather.net</title>
+ *   /de/privacy   <title>OneLiteFeather Network | OneLiteFeather.net</title>
+ *   /de/blog      <title>Übersicht | OneLiteFeather.net</title>
+ *
+ * Both legal pages do set a title through `definePageMeta`, which the layout
+ * renders via `<Title v-if="routeTitle">` — and `useSeoMeta` wins anyway. So
+ * the localised title existed, was declared, and never reached a single one of
+ * the three places that show it. A link to /de/imprint shared in Discord read
+ * "OneLiteFeather Network".
+ *
+ * Seven of the nine call sites already pass a title. This makes it nine.
+ */
+
+const PAGE_DIRS = ['pages']
+
+/** A `usePageSeo({ … })` call and its option object. */
+const CALL = /usePageSeo\(\{([\s\S]*?)\n\}\)/g
+
+function callsWithoutTitle(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(PAGE_DIRS, ['.vue'])) {
+    const text = readFileSync(file, 'utf8')
+    CALL.lastIndex = 0
+    for (const [, options] of text.matchAll(CALL)) {
+      if (!/^\s*title:/m.test(options!)) found.push(relativeToRepo(file))
+    }
+  }
+  return found
+}
+
+describe('page titles', () => {
+  it('finds the calls it is checking', () => {
+    // Without this, a renamed composable would make the rule vacuous.
+    const total = collectSourceFiles(PAGE_DIRS, ['.vue'])
+      .map((file) => readFileSync(file, 'utf8'))
+      .reduce((sum, text) => sum + [...text.matchAll(CALL)].length, 0)
+    expect(total).toBeGreaterThan(6)
+
+    // And the option detector has to tell the two shapes apart.
+    const withTitle = "usePageSeo({\n  title: t('x'),\n  description: 'd'\n})"
+    const without = "usePageSeo({\n  description: 'd',\n  robots: 'noindex, follow'\n})"
+    CALL.lastIndex = 0
+    expect(/^\s*title:/m.test([...withTitle.matchAll(CALL)][0]![1]!)).toBe(true)
+    CALL.lastIndex = 0
+    expect(/^\s*title:/m.test([...without.matchAll(CALL)][0]![1]!)).toBe(false)
+  })
+
+  it('are passed to usePageSeo, not left to the site-name fallback', () => {
+    expect(callsWithoutTitle()).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `SEO-06`, test-first.

## Omitting the title does not leave it alone

`usePageSeo` falls back to the site name when given no `title`, and that one value lands in `<title>`, `og:title` **and** `twitter:title`. Measured before the change:

```
/de/imprint   <title>OneLiteFeather Network | OneLiteFeather.net</title>
/de/privacy   <title>OneLiteFeather Network | OneLiteFeather.net</title>
/de/blog      <title>Übersicht | OneLiteFeather.net</title>
```

## Worse than the finding says

`SEO-06` describes this as an `og:title`/`twitter:title` problem and notes that `<Title v-if="routeTitle">` in the layout still renders the `definePageMeta` title. It does not: `useSeoMeta` wins, so the **document title itself** read "OneLiteFeather Network" too.

Both pages *did* declare `definePageMeta({ title: 'blog.imprint.title' })`, and the localised strings *were* in the locale files. The title existed, was declared, and reached none of the three places that show it. A link to `/de/imprint` shared in Discord read "OneLiteFeather Network".

## After

```
/de/imprint   <title>Impressum | OneLiteFeather.net</title>   og:title="Impressum"   twitter:title="Impressum"
/de/privacy   <title>Datenschutz | …</title>                  og:title="Datenschutz" twitter:title="Datenschutz"
/en/imprint   <title>Imprint | OneLiteFeather.net</title>
```

Three fields fixed per page, in both locales.

## The guard

Every `usePageSeo({ … })` call in `pages/` must pass a `title`. Seven of the nine already did; this makes it nine, and the rule keeps the next page from silently inheriting the site name.

The self-test pins the option detector against both shapes — a call with a title and one with only `description` and `robots` — so it cannot degrade into matching everything or nothing.

## Gates

Suite: 115 tests, 38 files. Build green. Ratchet unchanged at 334 / 39 / 21.

Refs: `SEO-06`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s