### PR TITLE
fix(config): stop $production concatenating arrays onto the base config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -108,8 +108,7 @@ export default defineNuxtConfig({
         strategy: 'prefix',
         defaultLocale: 'en',
         locales: [
-            {code: 'de', iso: 'de-DE', name: 'Deutsch', file: 'de.json'},
-            {code: 'en', iso: 'en-US', name: 'English', file: 'en.json'}
+            {code: 'de', iso: 'de-DE', name: 'Deutsch', file: 'de.json'}, {code: 'en', iso: 'en-US', name: 'English', file: 'en.json'}
         ],
         detectBrowserLanguage: {
             useCookie: true,
@@ -151,8 +150,7 @@ export default defineNuxtConfig({
     },
     // Include FontAwesome core styles (we set autoAddCss = false in the plugin)
     css: [
-        '@fortawesome/fontawesome-svg-core/styles.css',
-        '~/assets/css/tailwind.css'
+        '@fortawesome/fontawesome-svg-core/styles.css', '~/assets/css/tailwind.css'
     ],
     appConfig: {
         appId: 'OneLiteFeather',
@@ -204,7 +202,18 @@ export default defineNuxtConfig({
         build: {
             markdown: {
                 highlight: {
-                    langs: ['json', 'java', 'xml', 'js', 'ts', 'html', 'css', 'vue', 'shell', 'mdc', 'md', 'yaml'],
+                    langs: ['json',
+'java',
+'xml',
+'js',
+'ts',
+'html',
+'css',
+'vue',
+'shell',
+'mdc',
+'md',
+'yaml'],
                     theme: {
                         // Default theme (same as single string)
                         default: 'github-light',
@@ -236,20 +245,6 @@ export default defineNuxtConfig({
         }
     },
     $production: {
-        i18n: {
-            strategy: 'prefix',
-            defaultLocale: 'en',
-            locales: [
-                {code: 'de', iso: 'de-DE', name: 'Deutsch', file: 'de.json'},
-                {code: 'en', iso: 'en-US', name: 'English', file: 'en.json'}
-            ],
-            detectBrowserLanguage: {
-                useCookie: true,
-                cookieKey: 'i18n_redirected',
-                redirectOn: 'root' // recommended
-            },
-            baseUrl: 'https://onelitefeather.net',
-        },
         runtimeConfig: {
             public: {
                 siteUrl: 'https://onelitefeather.net',
@@ -268,57 +263,25 @@ export default defineNuxtConfig({
             }
         },
         schemaOrg: {
+            // Only the two absolute URLs differ from the base identity. The
+            // rest is merged in from there — repeating it would concatenate
+            // sameAs, contactPoint and availableLanguage rather than replace
+            // them, publishing each entry twice as schema.org fact.
             identity: defineOrganization({
+                // `name` only to satisfy defineOrganization's input type; it is
+                // a scalar, so defu replaces rather than appends it.
                 name: 'OneLiteFeather Network',
-                alternateName: 'OneLiteFeather.net',
-                description: 'OneLiteFeather is a Minecraft Network focusing on the development tools with intention to share with other servers.',
                 url: 'https://onelitefeather.net',
-                logo: 'https://onelitefeather.net/images/logo.svg',
-                email: 'contact@onelitefeather.net',
-                foundingDate: '2019-09-01',
-                numberOfEmployees: {
-                    '@type': 'QuantitativeValue',
-                    'minValue': 1,
-                    'maxValue': 25
-                },
-                address: {
-                    '@type': 'PostalAddress',
-                    streetAddress: 'Geisinger Straße 6',
-                    postalCode: '71634',
-                    addressLocality: 'Ludwigsburg',
-                    addressCountry: 'DE'
-                },
-                contactPoint: [
-                    {
-                        '@type': 'ContactPoint',
-                        contactType: 'customer support',
-                        email: 'contact@onelitefeather.net',
-                        availableLanguage: ['en', 'de']
-                    }
-                ],
-                sameAs: [
-                    'https://github.com/OneLiteFeatherNET',
-                    'https://1lf.link/discord',
-                    'https://opencollective.com/onelitefeather'
-                ]
+                logo: 'https://onelitefeather.net/images/logo.svg'
             })
-        },
-        posthog: {
-            publicKey: 'phc_t9nBlYL9LcDj4LDKZfQ97m5nbvFDTugkdQqAAspfdI',
-            host: 'https://eu.i.posthog.com',
-            proxy: true,
-            clientOptions: {
-                // Mirrors the base config above; see the comment there.
-                person_profiles: 'identified_only',
-                opt_out_capturing_by_default: true
-            }
         },
         site: {
             url: 'https://onelitefeather.net',
         },
         image: {
-            format: ['avif', 'webp'],
-            domains: ['mc-heads.net'],
+            // Only the delivery host differs; `format` and `domains` are
+            // declared in the base config and would be concatenated, not
+            // replaced, if repeated here.
             cloudflare: {
                 baseURL: 'https://img.onelitefeather.net',
             }

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "eslintErrors": 334,
+  "eslintErrors": 320,
   "eslintWarnings": 39,
   "typeErrors": 21
 }

--- a/tests/architecture/production-config.spec.ts
+++ b/tests/architecture/production-config.spec.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * `$production` is merged over the base config by c12 using @nuxt/kit's
+ * `createDefu` merger, and for two arrays that merger **concatenates**:
+ * `obj[key] = obj[key].concat(value)`. Repeating a list in `$production` does
+ * not override it, it doubles it.
+ *
+ * Loaded with `NODE_ENV=production` before the change:
+ *
+ *   schemaOrg.identity.sameAs   6 entries   (3 declared, twice)
+ *   schemaOrg.identity.contactPoint  2      (one object, twice)
+ *   i18n.locales                4           (de, en, de, en)
+ *   image.format                ['avif','webp','avif','webp']
+ *
+ * The schema.org duplication ships to Google as fact about the organisation.
+ * The doubled locale list is the one that could bite hardest — every consumer
+ * of `i18n.locales` iterates it, and hreflang generation is one of them.
+ *
+ * The rule below is therefore about arrays specifically: a list that appears in
+ * both blocks is never an override, only ever an append. Scalars are fine —
+ * `site.url` and `schemaOrg.identity.url` *should* appear in both, because
+ * that is what `$production` is for.
+ */
+
+const CONFIG = 'nuxt.config.ts'
+
+/** Top-level `key: [` array literals inside a block, by key path. */
+function arrayKeys(block: string): string[] {
+  return [...block.matchAll(/^(\s+)([\w'"]+):\s*\[/gm)].map(([, , key]) => key!.replace(/['"]/g, ''))
+}
+
+function blocks(): { base: string, production: string } {
+  const source = readFileSync(`${repoRoot}/${CONFIG}`, 'utf8')
+  const start = source.indexOf('    $production: {')
+  expect(start).toBeGreaterThan(0)
+  return { base: source.slice(0, start), production: source.slice(start) }
+}
+
+describe('production config overrides', () => {
+  it('finds both blocks', () => {
+    // Without this, an empty production block would satisfy every rule.
+    const { base, production } = blocks()
+    expect(base.length).toBeGreaterThan(1000)
+    expect(production.length).toBeGreaterThan(500)
+    expect(arrayKeys(base)).toContain('sameAs')
+  })
+
+  it('declares no array that the base config already declares', () => {
+    const { base, production } = blocks()
+    const inBase = new Set(arrayKeys(base))
+    const repeated = [...new Set(arrayKeys(production))]
+      .filter((key) => inBase.has(key))
+      .sort()
+
+    // Concatenated, not replaced — see the note above.
+    expect(repeated).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `SEO-04`, test-first.

## Repeating a list doubles it

c12 merges `$production` over the base with @nuxt/kit's `createDefu`, and for two arrays that merger does `obj[key] = obj[key].concat(value)`. Loaded with `NODE_ENV=production`:

| | before | after |
|---|---|---|
| `schemaOrg.identity.sameAs` | **6** | 3 |
| `schemaOrg.identity.contactPoint` | **2** | 1 |
| `i18n.locales` | **4** (de, en, de, en) | 2 |
| `image.format` | `['avif','webp','avif','webp']` | `['avif','webp']` |
| `image.domains` | 2 | 1 |

The schema.org duplication ships to Google as fact about the organisation. The doubled locale list is the one with the widest blast radius — everything that iterates `i18n.locales` saw each language twice, hreflang generation included.

## Verified by diffing the whole merged config

Config surgery earns a real check, not a spot check. I dumped every top-level key of the merged production config before and after and compared them recursively. **Five differences, all of them a halved array** — the five above. `nitro.preset`, `site.url`, `runtimeConfig.public.siteUrl`, `posthog`, `i18n.baseUrl`, `i18n.strategy`, `routeRules` and the rest are byte-identical.

(The only other delta was `app.buildId`, a fresh UUID per load — noise, excluded.)

## What was removed

The `i18n` and `posthog` blocks in `$production` repeated the base **verbatim** and are gone entirely. `image` keeps only `cloudflare.baseURL`. `schemaOrg.identity` keeps only the two absolute URLs that actually differ.

`name` stays in that identity block for one reason, stated in a comment: `defineOrganization`'s input type requires it. It is a scalar, so defu replaces rather than appends — checked, and `sameAs` is 3.

## The guard

The rule is specifically about **arrays**: a list declared in both blocks is never an override, only ever an append. Scalars are explicitly fine — `site.url` and `schemaOrg.identity.url` *should* appear in both, since that is what `$production` is for. Red on six keys (`sameAs`, `contactPoint`, `availableLanguage`, `locales`, `format`, `domains`).

## Gates

Suite: 117 tests, 39 files. Build green. Ratchet down 14 errors to 320 — the deleted duplication accounted for them.

Refs: `SEO-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s