### PR TITLE
fix(content): call composables in setup, not inside computed getters

### DIFF
--- a/components/content/ProseImg.vue
+++ b/components/content/ProseImg.vue
@@ -46,9 +46,12 @@ const isSvg = computed(() => {
   return pathOnly.toLowerCase().endsWith('.svg')
 })
 
+// Same reason as ProsePre: resolved during setup, not per getter evaluation.
+const runtimeConfig = useRuntimeConfig()
+
 const refinedSrc = computed(() => {
   if (isInternal.value) {
-    const _base = withLeadingSlash(withTrailingSlash(useRuntimeConfig().app.baseURL))
+    const _base = withLeadingSlash(withTrailingSlash(runtimeConfig.app.baseURL))
     if (_base !== '/' && !props.src.startsWith(_base)) {
       return joinURL(_base, props.src)
     }

--- a/components/content/ProsePre.vue
+++ b/components/content/ProsePre.vue
@@ -35,8 +35,13 @@ const props = defineProps({
   }
 })
 
+// At setup level, not inside the getter below. A composable resolves its
+// component via getCurrentInstance(), which is only set during setup — inside
+// a computed it happens to work because Vue falls back to the *rendering*
+// instance, and only while that getter runs as part of a render.
+const { t, te } = useI18n()
+
 const ariaLabel = computed(() => {
-  const { t, te } = useI18n()
   const parts: string[] = []
 
   if (props.filename) {

--- a/tests/architecture/composables-in-setup.spec.ts
+++ b/tests/architecture/composables-in-setup.spec.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * A composable resolves the component instance it belongs to via
+ * `getCurrentInstance()`, which is only set during setup. Called from inside a
+ * `computed` getter it works by accident: Vue's implementation is
+ * `currentInstance || currentRenderingInstance`, so while the getter is being
+ * evaluated *as part of a render* the rendering instance stands in.
+ *
+ * The accident holds only as long as nothing ever evaluates that computed
+ * outside a render pass — a watcher, a pre-flush job, a unit test that reads
+ * `.value`. vue-i18n throws `MUST_BE_CALL_SETUP_TOP` the moment it does not.
+ *
+ * `ProseHeading.vue` shows the shape this should have: `const { t, te } =
+ * useI18n()` beside `defineProps`, with the computed closing over it. Hoisting
+ * also stops the lookup repeating on every re-evaluation.
+ *
+ * Two files had it, not the one the finding names — `ProsePre` with
+ * `useI18n()` and `ProseImg` with `useRuntimeConfig()`.
+ */
+
+const SOURCE_DIRS = ['components',
+  'pages',
+  'layouts',
+  'composables']
+
+/** The body of a `computed(() => { … })` block. */
+const COMPUTED_BODY = /computed(?:<[^>]*>)?\(\(\) => \{(.*?)\n\}\)/gs
+/** A composable call: `useX(`. */
+const COMPOSABLE_CALL = /\b(use[A-Z]\w*)\s*\(/g
+
+function callsInsideComputed(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(SOURCE_DIRS, ['.vue', '.ts'])) {
+    const text = readFileSync(file, 'utf8')
+    COMPUTED_BODY.lastIndex = 0
+    for (const [, body] of text.matchAll(COMPUTED_BODY)) {
+      COMPOSABLE_CALL.lastIndex = 0
+      for (const [, name] of body!.matchAll(COMPOSABLE_CALL)) {
+        found.push(`${relativeToRepo(file)} — ${name}() inside a computed`)
+      }
+    }
+  }
+  return found
+}
+
+describe('composable call sites', () => {
+  it('recognises a computed body and a composable call', () => {
+    // Without this the check could pass by matching nothing at all.
+    const sample = 'const a = computed(() => {\n  const { t } = useI18n()\n  return t("x")\n})'
+    COMPUTED_BODY.lastIndex = 0
+    const bodies = [...sample.matchAll(COMPUTED_BODY)]
+    expect(bodies).toHaveLength(1)
+    COMPOSABLE_CALL.lastIndex = 0
+    expect([...bodies[0]![1]!.matchAll(COMPOSABLE_CALL)].map(([, n]) => n)).toEqual(['useI18n'])
+
+    // A composable hoisted above the computed is the correct shape.
+    const hoisted = 'const { t } = useI18n()\nconst a = computed(() => {\n  return t("x")\n})'
+    COMPUTED_BODY.lastIndex = 0
+    const body = [...hoisted.matchAll(COMPUTED_BODY)][0]![1]!
+    COMPOSABLE_CALL.lastIndex = 0
+    expect([...body.matchAll(COMPOSABLE_CALL)]).toHaveLength(0)
+  })
+
+  it('are all outside computed getters', () => {
+    expect(callsInsideComputed()).toEqual([])
+  })
+})


### PR DESCRIPTION
Implements `CNT-06`, test-first. The finding names one file; there are two.

## Why it works, and why that is the problem

A composable resolves its component through `getCurrentInstance()`, which is only set during setup. Called from inside a `computed` getter it works by accident: Vue's implementation is `currentInstance || currentRenderingInstance`, so while the getter runs *as part of a render* the rendering instance stands in.

That holds exactly as long as nothing evaluates the computed outside a render — a watcher, a pre-flush job, a unit test reading `.value`. vue-i18n throws `MUST_BE_CALL_SETUP_TOP` the moment it does.

| file | call |
|---|---|
| `ProsePre.vue` | `useI18n()` — the one the finding names |
| `ProseImg.vue` | `useRuntimeConfig()` — same shape, not mentioned |

`ProseHeading.vue` already has the right shape, with `const { t, te } = useI18n()` beside `defineProps` and the computed closing over it. Hoisting also stops the lookup repeating on every re-evaluation.

## Verified on the page that renders them

Both components are blog-article prose, so I rendered an article with seven code blocks and an image:

```
7 × <pre … aria-label="Code in yaml">
<img … src="/images/blog/cluster-topology-social.png">
```

The interpolated `"Code in yaml"` is the proof that matters — it is the hoisted `t` producing a translated, parameterised string, not a fallback.

Then the whole article, before and after, ignoring `<script>` blocks: **byte-identical, 99 961 both ways.**

## The guard

Flags any `useX()` call inside a `computed(() => { … })` body across `components`, `pages`, `layouts` and `composables`. The self-test pins both directions — a call inside the getter is caught, the same call hoisted above it is not — so it cannot decay into matching everything or nothing.

## Gates

Suite: 121 tests, 41 files. Build green. Ratchet unchanged at 334 / 39 / 21 (this branch is cut from `d63bc02`; #260 lowers the error count to 320 by a different route).

Refs: `CNT-06`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s