### PR TITLE
fix(navigation): stop the locale root marking every page as current

### DIFF
--- a/components/features/navigation/NavigationItem.vue
+++ b/components/features/navigation/NavigationItem.vue
@@ -19,9 +19,7 @@ const emit = defineEmits<{
 
 const route = useRoute();
 
-const isActive = computed(() => {
-  return route.path === props.path || route.path.startsWith(props.path + '/');
-});
+const isActive = computed(() => isCurrentNavPath(route.path, props.path));
 
 const handleClick = () => emit('click');
 

--- a/tests/architecture/nav-active-state.spec.ts
+++ b/tests/architecture/nav-active-state.spec.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+import { isCurrentNavPath } from '../../utils/navigation'
+
+/**
+ * Two nav items were lit at once on every subpage.
+ *
+ * `isActive` was `route.path === path || route.path.startsWith(path + '/')`.
+ * The prefix half is what keeps a section link current on its own subpages —
+ * `/de/team` staying lit on `/de/team/someone` — but the home link's path is
+ * the locale root, and `/de` is a prefix of *everything* under `/de`. So
+ * "Übersicht" was marked current on Team, Blog, Community-POIs and the rest.
+ *
+ * Measured on `/de/team` before the fix — two elements, not one:
+ *
+ *   <a href="/de"      aria-current="page">
+ *   <a href="/de/team" aria-current="page">
+ *
+ * `aria-current="page"` is the part that matters beyond the highlight: a
+ * screen reader announced two different links as the current page, which is
+ * not a styling nit but a false statement about where the user is.
+ *
+ * The rule is depth, not a hardcoded home path: a link matches by prefix only
+ * when it has a segment of its own below the locale root.
+ */
+
+const ITEM = 'components/features/navigation/NavigationItem.vue'
+
+describe('navigation active state', () => {
+  it('marks the exact page', () => {
+    expect(isCurrentNavPath('/de', '/de')).toBe(true)
+    expect(isCurrentNavPath('/de/team', '/de/team')).toBe(true)
+    expect(isCurrentNavPath('/en/blog', '/en/blog')).toBe(true)
+  })
+
+  it('keeps a section lit on its own subpages', () => {
+    // The reason prefix matching exists at all.
+    expect(isCurrentNavPath('/de/team/themeinerlp', '/de/team')).toBe(true)
+    expect(isCurrentNavPath('/de/blog/some-article', '/de/blog')).toBe(true)
+    expect(isCurrentNavPath('/de/community-poi/yggdrasil', '/de/community-poi')).toBe(true)
+  })
+
+  it('is a different answer than the rule it replaces', () => {
+    // The old implementation, verbatim. Without this the suite would pass
+    // just as well against the buggy version, and prove nothing.
+    const previous = (routePath: string, linkPath: string) => routePath === linkPath || routePath.startsWith(`${linkPath}/`)
+
+    expect(previous('/de/team', '/de')).toBe(true)
+    expect(isCurrentNavPath('/de/team', '/de')).toBe(false)
+
+    // And it must not have thrown out the behaviour that was correct.
+    expect(previous('/de/team/themeinerlp', '/de/team')).toBe(true)
+    expect(isCurrentNavPath('/de/team/themeinerlp', '/de/team')).toBe(true)
+  })
+
+  it('does not let the locale root claim every page', () => {
+    // The bug, in both locales.
+    expect(isCurrentNavPath('/de/team', '/de')).toBe(false)
+    expect(isCurrentNavPath('/de/blog/some-article', '/de')).toBe(false)
+    expect(isCurrentNavPath('/en/community-poi', '/en')).toBe(false)
+  })
+
+  it('does not match a sibling that merely shares a prefix', () => {
+    // `/de/team` must not light up on `/de/teams` or `/de/team-x`.
+    expect(isCurrentNavPath('/de/teams', '/de/team')).toBe(false)
+    expect(isCurrentNavPath('/de/team-archive', '/de/team')).toBe(false)
+  })
+
+  it('treats an unresolved link as inactive', () => {
+    expect(isCurrentNavPath('/de', '#')).toBe(false)
+    expect(isCurrentNavPath('/de', '')).toBe(false)
+  })
+
+  it('is what the component uses', () => {
+    const source = readFileSync(`${repoRoot}/${ITEM}`, 'utf8')
+    expect(source).toContain('isCurrentNavPath')
+    // The raw prefix test must be gone, not merely wrapped.
+    expect(source).not.toMatch(/route\.path\.startsWith\(props\.path/)
+  })
+})

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,0 +1,21 @@
+/**
+ * Whether a navigation link points at the page currently shown.
+ *
+ * Prefix matching is what makes a section link stay lit on its own subpages —
+ * `/de/team` should remain current on `/de/team/someone`. Applied to the
+ * locale root it does the opposite of what anyone wants: `/de` is a prefix of
+ * every page in that locale, so the home link would be current everywhere.
+ *
+ * So a link matches by prefix only if it has a segment of its own below the
+ * locale root; anything shallower has to match exactly.
+ */
+export function isCurrentNavPath(routePath: string, linkPath: string): boolean {
+  if (!linkPath || linkPath === '#') return false
+  if (routePath === linkPath) return true
+
+  // '/de' -> ['de'], '/de/team' -> ['de', 'team']
+  const segments = linkPath.split('/').filter(Boolean)
+  if (segments.length < 2) return false
+
+  return routePath.startsWith(`${linkPath}/`)
+}


### PR DESCRIPTION
Two nav items were highlighted at once on every subpage — reported from the Team page, where both "Übersicht" and "Team" were lit.

## Cause

```js
route.path === props.path || route.path.startsWith(props.path + '/')
```

The prefix half is what keeps a section link current on its own subpages — `/de/team` staying lit on `/de/team/someone`. But the home link's path *is* the locale root, and `/de` is a prefix of everything under it. So "Übersicht" was current on Team, Blog, Community-POIs and the rest.

Measured on `/de/team` before the fix:

```
<a href="/de"      aria-current="page">
<a href="/de/team" aria-current="page">
```

`aria-current` is the part that matters beyond the highlight — a screen reader announced two different links as the current page, which is a false statement about where the user is, not a styling nit.

## Not a regression from the audit work

Worth stating, since that was the initial suspicion. The rule dates to `f86f20b` (#40); `git log -S` finds no other commit touching it. My #237 edited this file but only swapped `variant` from a frozen constant to `withDefaults`.

Checked rather than argued: at `7f0f2a6^` — the commit immediately before #237 — `/de/team` already served both links with `aria-current="page"`.

## Fix

Depth, not a hardcoded home path: a link matches by prefix only when it has a segment of its own below the locale root. Extracted to `utils/navigation.ts` so it can be tested without a runtime.

After, across six routes:

```
/de                   → /de
/de/team              → /de/team
/de/blog              → /de/blog
/de/community-poi     → /de/community-poi
/en/blog              → /en/blog
/de/team/themeinerlp  → /de/team      ← prefix matching still works
```

## One thing that looks wrong in that output and is not

`/de/blog` also reports a second `aria-current="page"`. It is the **footer's** blog link, and the attribute comes from Vue Router itself (`router-link-exact-active`), not from this component — a link that genuinely points at the current page. Inside the navigation, exactly one item is current.

## The guard

The pure function is covered in both directions: exact match, section-with-subpage, locale root against every page, and a sibling that merely shares a prefix (`/de/teams` must not light `/de/team` — the old rule got that right too, via the trailing slash, and the new one keeps it).

One test holds the **old implementation verbatim** and asserts the two now disagree. Without it the suite would pass just as happily against the buggy version and prove nothing.

## Gates

Suite: 154 tests, 50 files. Build green. Ratchet unchanged at 319 / 36 / 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s