### PR TITLE
fix(community-poi): fall back to the placeholder when a thumbnail fails

### DIFF
--- a/components/features/community-poi/CommunityPoiCard.vue
+++ b/components/features/community-poi/CommunityPoiCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from '#imports'
+import { computed, ref, watch } from '#imports'
 import CommunityPoiStatusBadge from './CommunityPoiStatusBadge.vue'
 import CommunityPoiCategoryBadge from './CommunityPoiCategoryBadge.vue'
 import CommunityPoiProgressBar from './CommunityPoiProgressBar.vue'
@@ -9,6 +9,19 @@ import type { CommunityPoi } from '~/types/community-poi'
 const props = defineProps<{
   poi: CommunityPoi
 }>()
+
+// A thumbnail can be declared and still not arrive — the Cloudflare provider
+// fetches originals from the image origin, which does not hold every path that
+// exists in `public/`. Without this the browser draws its broken-image glyph
+// with the alt text spilled across the card; the placeholder below reads as a
+// missing picture, which is what it is.
+const thumbnailFailed = ref(false)
+
+// Cards are reused across list renders, so a stale flag would blank the next
+// POI shown in this slot.
+watch(() => props.poi.thumbnail, () => {
+  thumbnailFailed.value = false
+})
 
 const { locale, t } = useI18n()
 
@@ -69,7 +82,7 @@ const showcaseBadgeClass = [
   <article :class="articleClass">
     <NuxtLink :to="href" :aria-label="detailAria" :class="thumbLinkClass">
       <NuxtPicture
-        v-if="poi.thumbnail"
+        v-if="poi.thumbnail && !thumbnailFailed"
         :src="poi.thumbnail"
         :alt="poi.thumbnailAlt || poi.title"
         sizes="xs:300px sm:500px md:400px lg:500px"
@@ -80,6 +93,7 @@ const showcaseBadgeClass = [
         loading="lazy"
         :img-attrs="{ class: thumbImgClass }"
         format="avif,webp"
+        @error="thumbnailFailed = true"
       />
       <div v-else :class="placeholderClass">
         <IconFa :icon="['fas','image']" class="h-10 w-10" aria-hidden="true" />

--- a/tests/a11y/poi-card-image-behaviour.spec.ts
+++ b/tests/a11y/poi-card-image-behaviour.spec.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import CommunityPoiCard from '../../components/features/community-poi/CommunityPoiCard.vue'
+import type { CommunityPoi } from '../../types/community-poi'
+
+/**
+ * The static check in `poi-card-image-fallback.spec.ts` says the wiring is
+ * there. This one says it does something: emit `error` from the picture and
+ * the placeholder has to take its place.
+ *
+ * Server rendering cannot show this — a load failure is a client event, and
+ * the markup it produces looks identical either way until the browser tries
+ * to fetch. So the swap gets mounted and driven rather than read.
+ */
+
+const poi = {
+  slug: 'labyrinth',
+  title: 'Labyrinth von B3nNy',
+  thumbnail: '/community-poi/labyrinth/cover.webp',
+  thumbnailAlt: 'Render des Labyrinths',
+  status: 'in_progress',
+  progress: 40
+} as unknown as CommunityPoi
+
+const stubs = {
+  NuxtPicture: { name: 'NuxtPicture', template: '<picture data-test="thumb" />' },
+  NuxtLink: { name: 'NuxtLink', template: '<a><slot /></a>' },
+  IconFa: { name: 'IconFa', template: '<i data-test="placeholder" />' },
+  CommunityPoiStatusBadge: true,
+  CommunityPoiCategoryBadge: true,
+  CommunityPoiProgressBar: true
+}
+
+// The card calls `useI18n()`, which needs a real instance rather than a mock.
+// `legacy: false` as a literal via the generic — inferring it from the option
+// alone leaves createI18n's overloads ambiguous (TS2769).
+const i18n = createI18n<false>({ legacy: false, locale: 'de', messages: { de: {}, en: {} } })
+
+const mountCard = () => mount(CommunityPoiCard, {
+  props: { poi },
+  global: { stubs, plugins: [i18n] }
+})
+
+describe('POI card, driven', () => {
+  it('replaces a failed thumbnail with the placeholder', async () => {
+    const wrapper = mountCard()
+
+    expect(wrapper.find('[data-test="thumb"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="placeholder"]').exists()).toBe(false)
+
+    await wrapper.findComponent({ name: 'NuxtPicture' }).vm.$emit('error')
+
+    // The picture is gone and the placeholder stands in its place — the same
+    // one a POI with no thumbnail at all gets.
+    expect(wrapper.find('[data-test="thumb"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="placeholder"]').exists()).toBe(true)
+  })
+
+  it('recovers when the slot shows a different POI', async () => {
+    const wrapper = mountCard()
+    await wrapper.findComponent({ name: 'NuxtPicture' }).vm.$emit('error')
+    expect(wrapper.find('[data-test="thumb"]').exists()).toBe(false)
+
+    // List renders reuse cards. Without the reset, this POI's picture would
+    // stay hidden because a previous one failed.
+    const other = { ...poi, slug: 'yggdrasil', thumbnail: '/images/x.webp' }
+    await wrapper.setProps({ poi: other })
+
+    expect(wrapper.find('[data-test="thumb"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="placeholder"]').exists()).toBe(false)
+  })
+})

--- a/tests/a11y/poi-card-image-fallback.spec.ts
+++ b/tests/a11y/poi-card-image-fallback.spec.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { repoRoot } from '../helpers/sources'
+
+/**
+ * The card already draws a placeholder when a POI has no thumbnail at all —
+ * `v-if="poi.thumbnail"` / `v-else`. What it had no answer for is a thumbnail
+ * that is *declared* and fails to load: the browser then shows its broken-image
+ * glyph with the alt text spilled across the card, which reads as a rendering
+ * fault rather than a missing picture.
+ *
+ * That is not hypothetical. `/community-poi/labyrinth/cover.webp` is declared,
+ * exists in `public/`, and 404s on the image origin the Cloudflare provider
+ * fetches from — see `tests/content/image-paths.spec.ts` for the measurements.
+ *
+ * So the same placeholder now covers both cases: nothing declared, and
+ * something declared that did not arrive. The `@error` handler is what turns
+ * the second into the first.
+ *
+ * Note this hides a broken reference behind a tidy placeholder, which is why
+ * it ships alongside a check that fails on the reference itself. A fallback
+ * without that check would make the next broken path invisible.
+ */
+
+const CARD = 'components/features/community-poi/CommunityPoiCard.vue'
+
+function card(): string {
+  return readFileSync(`${repoRoot}/${CARD}`, 'utf8')
+}
+
+describe('POI card image fallback', () => {
+  it('tracks whether the thumbnail failed', () => {
+    const source = card()
+    expect(source).toMatch(/const thumbnailFailed = ref\(false\)/)
+    // The picture element has to report the failure.
+    expect(source).toMatch(/@error[^"]*="[^"]*thumbnailFailed/)
+  })
+
+  it('shows the placeholder for a failure, not just for an absent thumbnail', () => {
+    const source = card()
+    // The condition that decides between picture and placeholder must consider
+    // both — a declared-but-broken thumbnail is a missing picture too.
+    expect(source).toMatch(/v-if="poi\.thumbnail && !thumbnailFailed"/)
+    expect(source).toMatch(/<div v-else/)
+  })
+
+  it('resets when the POI changes', () => {
+    // Cards are reused across list renders; a stale failure flag would blank
+    // the picture of the next POI shown in that slot.
+    const source = card()
+    expect(source).toMatch(/watch\(\s*\(\) => props\.poi\.thumbnail/)
+  })
+})

--- a/tests/content/image-paths.spec.ts
+++ b/tests/content/image-paths.spec.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { collectSourceFiles, relativeToRepo } from '../helpers/sources'
+
+/**
+ * Content images are served through @nuxt/image's Cloudflare provider in
+ * production, which fetches the original from `img.onelitefeather.net` — a
+ * different origin from the site itself. That origin holds `/images/**` and
+ * nothing else.
+ *
+ * Measured against it directly:
+ *
+ *   /images/blog/dev-blog-1.webp                      200
+ *   /images/community-poi/yggdrasil/krone-innen.webp  200
+ *   /community-poi/labyrinth/cover.webp               404
+ *   /community-poi/labyrinth/result.webp              404
+ *   /community-poi/labyrinth/progress_1.webp          404
+ *
+ * A file in `public/` is therefore not enough. `public/community-poi/labyrinth/
+ * cover.webp` exists in this repository and resolves on the site origin — and
+ * still renders as a broken image, because that is not where the picture
+ * element looks.
+ *
+ * The failure is invisible to every check that stops at the repository: the
+ * file is there, the path is spelled right, the build passes. Only the browser
+ * finds out.
+ *
+ * Ten content images follow the convention. The ten that do not are all one
+ * POI, listed below until its images reach the origin.
+ */
+
+const CONTENT_DIRS = ['content']
+
+/** `thumbnail: '/x.webp'`, `headerImage: 'images/y.png'`, gallery `src:` … */
+const IMAGE_REFERENCE = /(?:headerImage|thumbnail|image|src):\s*'([^']+\.(?:webp|png|jpe?g|svg))'/g
+
+/**
+ * Known offenders, pending upload of `public/community-poi/labyrinth/**` to
+ * the image origin (or a move under `/images/`).
+ *
+ * Listed rather than silently skipped: whoever fixes the origin deletes this
+ * entry, and until then these paths cannot be mistaken for working ones.
+ */
+const AWAITING_UPLOAD = /^\/community-poi\/labyrinth\//
+
+function offenders(): string[] {
+  const found: string[] = []
+  for (const file of collectSourceFiles(CONTENT_DIRS, ['.md', '.json'])) {
+    const text = readFileSync(file, 'utf8')
+    IMAGE_REFERENCE.lastIndex = 0
+    for (const [, path] of text.matchAll(IMAGE_REFERENCE)) {
+      if (AWAITING_UPLOAD.test(path!)) continue
+      // Both `/images/…` and `images/…` reach the same origin path.
+      if (/^\/?images\//.test(path!)) continue
+      found.push(`${relativeToRepo(file)} — ${path}`)
+    }
+  }
+  return found
+}
+
+describe('content image paths', () => {
+  it('finds the references it checks', () => {
+    // Without this, a changed frontmatter key would pass the rule vacuously.
+    const all: string[] = []
+    for (const file of collectSourceFiles(CONTENT_DIRS, ['.md', '.json'])) {
+      IMAGE_REFERENCE.lastIndex = 0
+      for (const [, path] of readFileSync(file, 'utf8').matchAll(IMAGE_REFERENCE)) all.push(path!)
+    }
+    expect(all.length).toBeGreaterThan(15)
+    expect(all.some((p) => /^\/?images\//.test(p))).toBe(true)
+
+    // And the exemption must still be describing something real.
+    expect(all.some((p) => AWAITING_UPLOAD.test(p))).toBe(true)
+  })
+
+  it('are all under the prefix the image origin serves', () => {
+    expect(offenders()).toEqual([])
+  })
+})


### PR DESCRIPTION
The Community-POI overview showed a broken-image glyph with alt text spilled across the middle card. Two changes: the placeholder now covers a *failed* thumbnail as well as an absent one, and a check catches the reference that caused it.

## The cause is not what it looks like

The third card (Hafengebäude) already renders a placeholder correctly — it has no thumbnail. The second (Labyrinth) has one that does not load, and the reason is where the file lives:

| path | site origin | image origin (`img.onelitefeather.net`) |
|---|---|---|
| `/community-poi/labyrinth/cover.webp` | 200 | **404** |
| `/community-poi/labyrinth/result.webp` | 200 | **404** |
| `/images/community-poi/yggdrasil/cover.webp` | **404** | 200 |
| `/images/blog/dev-blog-1.webp` | — | 200 |

`NuxtPicture` uses the Cloudflare provider in production, which fetches originals from the **image origin**, not from the site. That origin serves `/images/**` and nothing else. So a file sitting in `public/` is not enough — Labyrinth's images exist in this repository and 404 where the picture element actually looks. Yggdrasil is the mirror image: on the origin, not in the repo.

Counted across all content: **10 image references under `images/`, 10 not** — and all ten exceptions are this one POI.

## Two changes, because one alone would be worse

**The fallback** turns a failed load into the same placeholder a POI with no thumbnail gets. `@error` sets a flag; the flag resets when the card is handed a different POI, since list renders reuse the component and a stale flag would blank the *next* POI shown in that slot.

**The path check** is why the fallback is safe to add. On its own it would hide the broken reference behind something tidy and make the next one invisible. The check fails on any content image path outside `images/`, with the labyrinth paths listed as a named exemption — pending upload to the origin, or a move under `/images/`. Whoever fixes that deletes the entry.

## Verified by driving it, not reading it

A load failure is a client event; SSR output looks identical either way. So the card gets mounted and the picture emits `error`:

```
before:  <picture> present, placeholder absent
after:   <picture> gone,    placeholder present
```

And with the reset removed, both assertions fail — so the test is testing the fix, not the mount.

## Not fixed here

**The Labyrinth images are still missing from the image origin.** This PR stops that looking like a rendering fault; it does not put the picture back. That needs `public/community-poi/labyrinth/**` uploaded to `img.onelitefeather.net` (or moved under `/images/`), which is infrastructure I can't reach.

## Gates

Suite: 154 tests, 52 files. Build green. Ratchet unchanged at 319 / 36 / 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uWFJwn6dswmNtR8kKB86s